### PR TITLE
[Feature] Trade · Chat 도메인 엔티티 및 뼈대 구조 초기 생성

### DIFF
--- a/src/main/java/com/windfall/api/chat/controller/ChatController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatController.java
@@ -1,0 +1,10 @@
+package com.windfall.api.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+}

--- a/src/main/java/com/windfall/api/chat/service/ChatService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatService.java
@@ -1,0 +1,10 @@
+package com.windfall.api.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+}

--- a/src/main/java/com/windfall/api/trade/controller/TradeController.java
+++ b/src/main/java/com/windfall/api/trade/controller/TradeController.java
@@ -1,0 +1,10 @@
+package com.windfall.api.trade.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TradeController {
+
+}

--- a/src/main/java/com/windfall/api/trade/service/TradeService.java
+++ b/src/main/java/com/windfall/api/trade/service/TradeService.java
@@ -1,0 +1,10 @@
+package com.windfall.api.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TradeService {
+
+}

--- a/src/main/java/com/windfall/domain/chat/entity/ChatImage.java
+++ b/src/main/java/com/windfall/domain/chat/entity/ChatImage.java
@@ -1,0 +1,29 @@
+package com.windfall.domain.chat.entity;
+
+import com.windfall.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatImage extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "chat_message_id", nullable = false)
+  private ChatMessage chatMessage;
+
+  @Column(name = "image_url", nullable = false)
+  private String imageUrl;
+
+}

--- a/src/main/java/com/windfall/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/windfall/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,44 @@
+package com.windfall.domain.chat.entity;
+
+import com.windfall.domain.chat.enums.ChatMessageType;
+import com.windfall.domain.user.entity.User;
+import com.windfall.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatMessage extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "chat_room_id", nullable = false)
+  private ChatRoom chatRoom;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "sender_id", nullable = false)
+  private User sender;
+
+  @Column(columnDefinition = "TEXT", nullable = false)
+  private String content;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "message_type", nullable = false)
+  private ChatMessageType messageType;
+
+  @Column(name = "is_read", nullable = false)
+  private boolean isRead;
+
+}

--- a/src/main/java/com/windfall/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/windfall/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,34 @@
+package com.windfall.domain.chat.entity;
+
+import com.windfall.domain.trade.entity.Trade;
+import com.windfall.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatRoom extends BaseEntity {
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "trade_id", nullable = false, unique = true)
+  private Trade trade;
+
+  @Column(name = "last_message_at")
+  private LocalDateTime lastMessageAt;
+
+  @Column(name = "last_message_preview", length = 200)
+  private String lastMessagePreview;
+
+}

--- a/src/main/java/com/windfall/domain/chat/enums/ChatMessageType.java
+++ b/src/main/java/com/windfall/domain/chat/enums/ChatMessageType.java
@@ -1,0 +1,14 @@
+package com.windfall.domain.chat.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ChatMessageType {
+  TEXT("텍스트"),
+  IMAGE("이미지"),
+  SYSTEM("시스템 메시지");
+
+  private final String description;
+}

--- a/src/main/java/com/windfall/domain/chat/repository/ChatImageRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatImageRepository.java
@@ -1,0 +1,8 @@
+package com.windfall.domain.chat.repository;
+
+import com.windfall.domain.chat.entity.ChatImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatImageRepository extends JpaRepository<ChatImage, Long> {
+
+}

--- a/src/main/java/com/windfall/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package com.windfall.domain.chat.repository;
+
+import com.windfall.domain.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+}

--- a/src/main/java/com/windfall/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.windfall.domain.chat.repository;
+
+import com.windfall.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+}

--- a/src/main/java/com/windfall/domain/review/entity/Review.java
+++ b/src/main/java/com/windfall/domain/review/entity/Review.java
@@ -1,9 +1,12 @@
 package com.windfall.domain.review.entity;
 
 
+import com.windfall.domain.trade.entity.Trade;
 import com.windfall.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,7 +17,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {
 
-  //@OneToOne - Trade 엔티티 생성 이후 매핑 예정
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "trade_id", nullable = false, unique = true)
+  private Trade trade;
 
   @Column(name = "buyer_id", nullable = false)
   private Long buyerId;

--- a/src/main/java/com/windfall/domain/trade/entity/Trade.java
+++ b/src/main/java/com/windfall/domain/trade/entity/Trade.java
@@ -1,0 +1,44 @@
+package com.windfall.domain.trade.entity;
+
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.trade.enums.TradeStatus;
+import com.windfall.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Trade extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "auction_id", nullable = false)
+  private Auction auction;
+
+  @Column(name = "buyer_id", nullable = false)
+  private Long buyerId;
+
+  @Column(name = "seller_id", nullable = false)
+  private Long sellerId;
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private TradeStatus status = TradeStatus.PENDING;
+
+  @Column(name = "final_price", nullable = false)
+  private Long finalPrice;
+
+}

--- a/src/main/java/com/windfall/domain/trade/enums/TradeStatus.java
+++ b/src/main/java/com/windfall/domain/trade/enums/TradeStatus.java
@@ -1,0 +1,16 @@
+package com.windfall.domain.trade.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TradeStatus {
+  PENDING("결제 대기"),
+  PAYMENT_CANCELED("결제 취소"),
+  PAYMENT_COMPLETED("결제 완료"),
+  PURCHASE_CONFIRMED("구매 확정"),
+  PAYMENT_FAILED("결제 실패");
+
+  private final String description;
+}

--- a/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
@@ -1,0 +1,8 @@
+package com.windfall.domain.trade.repository;
+
+import com.windfall.domain.trade.entity.Trade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeRepository extends JpaRepository<Trade, Long> {
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #27 

## 📝 변경 사항
### AS-IS
* Trade 도메인 및 채팅 도메인이 존재하지 않았음
* Review 엔티티가 Trade와의 연관관계를 포함하지 않았음
* 채팅 기능 개발을 위한 Controller/Service/Repository 구조 부재

### TO-BE
* Trade 엔티티 생성 및 Auction과의 연관관계 설정
* TradeStatus Enum 추가하여 거래 상태 관리
* ChatRoom / ChatMessage / ChatImage / ChatMessageType 등
  채팅 기능 구현을 위한 핵심 엔티티 생성
* Review 엔티티에 Trade와의 1:1 관계 추가
* 각 도메인별 Controller/Service/Repository 기본 템플릿 생성
* 이후 기능 개발을 위한 기반 구조 마련됨

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
* 이번 PR은 **구조(틀)**만 생성한 단계입니다.
  실제 로직/쿼리/메서드는 이후 단계에서 점진적으로 구현 예정입니다.
* 엔티티 간 연관관계 모델링이 적절한지, 개선해야 할 점은 없는지 검토 부탁드립니다.
* 특히 Chat 도메인 구조(ChatRoom 1:1 Trade / ChatMessage / ChatImage) 검토 부탁드립니다.