### PR TITLE
[Feature] Redis를 활용한 실시간 접속자 수 집계 로직 구현

### DIFF
--- a/src/main/java/com/windfall/api/auction/dto/response/AuctionDetailResponse.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/AuctionDetailResponse.java
@@ -51,7 +51,7 @@ public record AuctionDetailResponse(
     boolean isLiked,
 
     @Schema(description = "실시간 접속자 수")
-    Long viewCount,
+    Long viewerCount,
 
     @Schema(description = "경매 시작 시간")
     LocalDateTime startedAt,
@@ -66,6 +66,7 @@ public record AuctionDetailResponse(
       Double discountRate,
       Long stopLoss,
       boolean isLiked,
+      Long viewerCount,
       List<AuctionHistoryResponse> history
   ) {
     return new AuctionDetailResponse(
@@ -82,7 +83,7 @@ public record AuctionDetailResponse(
         auction.getStatus(),
         0L, // auction.getLikeCount(),
         isLiked,
-        0L, // auction.getViewCount(),
+        viewerCount,
         auction.getStartedAt(),
         history
     );

--- a/src/main/java/com/windfall/api/auction/service/AuctionService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionService.java
@@ -116,7 +116,11 @@ public class AuctionService {
     }
 
     boolean isSeller = auction.isSeller(userId);
-    Long exposedStopLoss = isSeller ? auction.getStopLoss() : null;
+
+    Long exposedStopLoss = null;
+    if (isSeller) {
+      exposedStopLoss = auction.getStopLoss();
+    }
 
     // TODO: 타 도메인 의존성 처리 (User, Like)
     // TODO: websocket 실시간 조회수 처리, 가격 하락 처리
@@ -147,7 +151,11 @@ public class AuctionService {
     }
 
     Long viewerCount = redisTemplate.opsForSet().size(redisKey);
-    return viewerCount != null ? viewerCount : 0L;
+
+    if (viewerCount == null) {
+      return 0L;
+    }
+    return viewerCount;
   }
 
   private List<AuctionHistoryResponse> getRecentHistories(Long auctionId) {

--- a/src/main/java/com/windfall/api/auction/service/AuctionService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionService.java
@@ -56,7 +56,6 @@ public class AuctionService {
     }
   }
 
-
   @Transactional
   public AuctionCancelResponse cancelAuction(Long auctionId, Long userId) {
     User user = userService.getUserById(userId);
@@ -101,19 +100,9 @@ public class AuctionService {
     }
   }
 
-  private void validateIsSeller(Auction auction, User user) {
-    if (user != auction.getSeller()) {
-      throw new ErrorException(ErrorCode.INVALID_AUCTION_SELLER);
-    }
-  }
-  public Auction getAuctionById(Long auctionId) {
-    return auctionRepository.findById(auctionId)
-        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
-  }
-
   public AuctionDetailResponse getAuctionDetail(Long auctionId, Long userId) {
 
-    Auction auction = findAuctionOrThrow(auctionId);
+    Auction auction = getAuctionById(auctionId);
 
     Long displayPrice = auction.getDisplayPrice();
 
@@ -148,7 +137,12 @@ public class AuctionService {
         .toList();
   }
 
-  private Auction findAuctionOrThrow(Long auctionId) {
+  private void validateIsSeller(Auction auction, User user) {
+    if (user != auction.getSeller()) {
+      throw new ErrorException(ErrorCode.INVALID_AUCTION_SELLER);
+    }
+  }
+  public Auction getAuctionById(Long auctionId) {
     return auctionRepository.findById(auctionId)
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
   }


### PR DESCRIPTION
## 📌 관련 이슈
- close #31 

## 📝 변경 사항
### AS-IS
- 경매 상세 조회 시, 실시간 접속자 수(viewCount) 필드에 0L이 하드코딩되어 반환
- 접속자 수를 저장하거나 집계하는 로직 부재

### TO-BE
- Redis 기반 집계 로직 추가:
   - 경매 상세 조회 API가 호출될 때마다, userId를 Redis Set 자료구조에 저장
   - Set을 사용하여 동일 유저의 반복 요청(새로고침)에 의한 중복 카운팅 방지

- TTL 적용:
  - WebSocket 미구현으로 Redis Key에 만료 시간 설정
  - 유저의 활동이 없으면(API 호출 중단 시) 자동으로 접속자 목록에서 제거되어 카운트가 감소하도록 처리

- DTO 매핑 수정:
   - `AuctionDetailResponse.of()` 메서드에서 viewerCount를 인자로 받아 응답에 포함하도록 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- ` uerId = 1L` 호출
<img width="738" height="704" alt="image" src="https://github.com/user-attachments/assets/dd100a79-7f6d-48c9-a692-7a1e329b3a6c" />

- `userId = 2L` / `userId = null` 호출
<img width="698" height="710" alt="image" src="https://github.com/user-attachments/assets/12683086-0e36-4de8-88bc-853360620a9c" />

- 1분 경과 후 
  - 비회원으로 호출 시 집계가 안되므로 '0' 확인
<img width="186" height="60" alt="image" src="https://github.com/user-attachments/assets/b44aac75-bbea-4d36-9091-f6063b13ec1b" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
아직 WebSocket이 도입되기 전 단계이므로, 1L이 우선적으로 만료가 되어도 서버에서는 알 수 없어 2L까지 만료된 이후의 값 0만 확인 가능합니다 