### PR TITLE
[Feature] 경매 상세 스케줄러 도입

### DIFF
--- a/src/main/java/com/windfall/WindfallApplication.java
+++ b/src/main/java/com/windfall/WindfallApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
 @SpringBootApplication
 public class WindfallApplication {
 

--- a/src/main/java/com/windfall/WindfallApplication.java
+++ b/src/main/java/com/windfall/WindfallApplication.java
@@ -2,7 +2,9 @@ package com.windfall;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class WindfallApplication {
 

--- a/src/main/java/com/windfall/api/auction/dto/response/AuctionDetailResponse.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/AuctionDetailResponse.java
@@ -30,28 +30,28 @@ public record AuctionDetailResponse(
     SellerInfo seller,
 
     @Schema(description = "시작가")
-    Long startPrice,
+    long startPrice,
 
     @Schema(description = "현재가 (예정 : 시작가)")
-    Long currentPrice,
+    long currentPrice,
 
     @Schema(description = "최소 보장가 (판매자만)")
-    Long stopLoss,
+    long stopLoss,
 
     @Schema(description = "하락 퍼센트 (예정 : null)")
-    Double discountRate,
+    double discountRate,
 
     @Schema(description = "경매 상태")
     AuctionStatus status,
 
     @Schema(description = "찜 수")
-    Long likeCount,
+    long likeCount,
 
     @Schema(description = "사용자 찜 여부")
     boolean isLiked,
 
     @Schema(description = "실시간 접속자 수")
-    Long viewerCount,
+    long viewerCount,
 
     @Schema(description = "경매 시작 시간")
     LocalDateTime startedAt,
@@ -62,11 +62,11 @@ public record AuctionDetailResponse(
 ) {
   public static AuctionDetailResponse of(
       Auction auction,
-      Long currentPrice,
-      Double discountRate,
-      Long stopLoss,
+      long currentPrice,
+      double discountRate,
+      long stopLoss,
       boolean isLiked,
-      Long viewerCount,
+      long viewerCount,
       List<AuctionHistoryResponse> history
   ) {
     return new AuctionDetailResponse(

--- a/src/main/java/com/windfall/api/auction/dto/response/AuctionHistoryResponse.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/AuctionHistoryResponse.java
@@ -11,10 +11,10 @@ public record AuctionHistoryResponse(
     Long historyId,
 
     @Schema(description = "변경된 가격")
-    Long currentPrice,
+    long currentPrice,
 
     @Schema(description = "시점 접속자 수")
-    Long viewerCount,
+    long viewerCount,
 
     @Schema(description = "가격 변동 시점")
     LocalDateTime createdAt

--- a/src/main/java/com/windfall/api/auction/scheduler/AuctionScheduler.java
+++ b/src/main/java/com/windfall/api/auction/scheduler/AuctionScheduler.java
@@ -1,0 +1,79 @@
+package com.windfall.api.auction.scheduler;
+
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.entity.AuctionPriceHistory;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import com.windfall.domain.auction.repository.AuctionPriceHistoryRepository;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuctionScheduler {
+
+  private final AuctionRepository auctionRepository;
+  private final AuctionPriceHistoryRepository historyRepository;
+
+  @Scheduled(cron = "0 0/5 * * * *")
+  @Transactional
+  public void runAuctionScheduler() {
+    LocalDateTime now = LocalDateTime.now();
+    log.info("스케줄러 실행: {}", now);
+
+    openScheduledAuctions(now);
+
+    dropAuctionPrices(now);
+  }
+
+  private void openScheduledAuctions(LocalDateTime now) {
+    List<Auction> startingAuctions = auctionRepository.findAllByStatusAndStartedAtLessThanEqual(
+        AuctionStatus.SCHEDULED, now
+    );
+
+    for (Auction auction : startingAuctions) {
+      auction.updateStatus(AuctionStatus.PROCESS);
+      log.info("경매 시작 처리 완료 ( 경매 ID: {}, 제목: {} )", auction.getId(), auction.getTitle());
+    }
+  }
+
+  private void dropAuctionPrices(LocalDateTime now) {
+    List<Auction> activeAuctions = auctionRepository.findAllByStatus(AuctionStatus.PROCESS);
+
+    for(Auction auction : activeAuctions) {
+      long minutesElapsed = java.time.Duration.between(auction.getStartedAt(), now).toMinutes();
+      long dropCount = minutesElapsed / 5;
+
+      if(dropCount > 0) {
+        long totalDiscount = dropCount * auction.getDropAmount();
+        long targetPrice = auction.getStartPrice() - totalDiscount;
+
+        if(targetPrice < auction.getStopLoss()) {
+          log.info("경매 유찰 ( 경매 ID: {}, StopLoss 도달)", auction.getId());
+          auction.updateStatus(AuctionStatus.FAILED);
+
+          auction.updateCurrentPrice(auction.getStopLoss());
+        }
+        else {
+          if(targetPrice < auction.getCurrentPrice()) {
+            auction.updateCurrentPrice(targetPrice);
+            savePriceHistory(auction, targetPrice);
+            log.info("경매 가격 하락 처리 완료 ( 경매 ID: {}, 가격: {} -> {}",
+                auction.getId(), auction.getCurrentPrice(), targetPrice);
+          }
+        }
+      }
+    }
+  }
+
+  private void savePriceHistory(Auction auction, long targetPrice) {
+    AuctionPriceHistory history = AuctionPriceHistory.create(auction, targetPrice, 0L);
+    historyRepository.save(history);
+  }
+}

--- a/src/main/java/com/windfall/api/auction/scheduler/AuctionScheduler.java
+++ b/src/main/java/com/windfall/api/auction/scheduler/AuctionScheduler.java
@@ -62,6 +62,7 @@ public class AuctionScheduler {
           auction.updateStatus(AuctionStatus.FAILED);
 
           auction.updateCurrentPrice(auction.getStopLoss());
+          savePriceHistoryWithViewers(auction, auction.getStopLoss());
         }
         else {
           if(targetPrice < auction.getCurrentPrice()) {

--- a/src/main/java/com/windfall/api/auction/scheduler/AuctionScheduler.java
+++ b/src/main/java/com/windfall/api/auction/scheduler/AuctionScheduler.java
@@ -1,93 +1,26 @@
 package com.windfall.api.auction.scheduler;
 
-import com.windfall.domain.auction.entity.Auction;
-import com.windfall.domain.auction.entity.AuctionPriceHistory;
-import com.windfall.domain.auction.enums.AuctionStatus;
-import com.windfall.domain.auction.repository.AuctionPriceHistoryRepository;
-import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.api.auction.service.AuctionSchedulerService;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class AuctionScheduler {
 
-  private final AuctionRepository auctionRepository;
-  private final AuctionPriceHistoryRepository historyRepository;
-
-  private final RedisTemplate<String, String> redisTemplate;
+  private final AuctionSchedulerService auctionSchedulerService;
 
   @Scheduled(cron = "0 0/5 * * * *")
-  @Transactional
   public void runAuctionScheduler() {
     LocalDateTime now = LocalDateTime.now();
     log.info("⏱️스케줄러 실행: {}", now);
 
-    openScheduledAuctions(now);
+    auctionSchedulerService.openScheduledAuctions(now);
 
-    dropAuctionPrices(now);
-  }
-
-  private void openScheduledAuctions(LocalDateTime now) {
-    List<Auction> startingAuctions = auctionRepository.findAllByStatusAndStartedAtLessThanEqual(
-        AuctionStatus.SCHEDULED, now
-    );
-
-    for (Auction auction : startingAuctions) {
-      auction.updateStatus(AuctionStatus.PROCESS);
-      log.info("✅경매 시작 처리 완료 ( 경매 ID: {}, 제목: {} )", auction.getId(), auction.getTitle());
-    }
-  }
-
-  private void dropAuctionPrices(LocalDateTime now) {
-    List<Auction> activeAuctions = auctionRepository.findAllByStatus(AuctionStatus.PROCESS);
-
-    for(Auction auction : activeAuctions) {
-      long minutesElapsed = java.time.Duration.between(auction.getStartedAt(), now).toMinutes();
-      long dropCount = minutesElapsed / 5;
-
-      if(dropCount > 0) {
-        long totalDiscount = dropCount * auction.getDropAmount();
-        long targetPrice = auction.getStartPrice() - totalDiscount;
-
-        if(targetPrice < auction.getStopLoss()) {
-          log.info("❌경매 유찰 ( 경매 ID: {}, StopLoss 도달)", auction.getId());
-          auction.updateStatus(AuctionStatus.FAILED);
-
-          auction.updateCurrentPrice(auction.getStopLoss());
-          savePriceHistoryWithViewers(auction, auction.getStopLoss());
-        }
-        else {
-          if(targetPrice < auction.getCurrentPrice()) {
-            long oldPrice = auction.getCurrentPrice();
-
-            auction.updateCurrentPrice(targetPrice);
-            savePriceHistoryWithViewers(auction, targetPrice);
-
-            log.info("📉경매 가격 하락 처리 완료 ( 경매 ID: {}, 가격: {} -> {}",
-                auction.getId(), oldPrice, targetPrice);
-          }
-        }
-      }
-    }
-  }
-
-  private void savePriceHistoryWithViewers(Auction auction, long targetPrice) {
-    String redisKey = "auction:" + auction.getId() + ":viewers";
-
-    Long viewerCount = redisTemplate.opsForSet().size(redisKey);
-    if (viewerCount == null) {
-      viewerCount = 0L;
-    }
-
-    AuctionPriceHistory history = AuctionPriceHistory.create(auction, targetPrice, viewerCount);
-    historyRepository.save(history);
+    auctionSchedulerService.dropAuctionPrices(now);
   }
 }

--- a/src/main/java/com/windfall/api/auction/scheduler/AuctionScheduler.java
+++ b/src/main/java/com/windfall/api/auction/scheduler/AuctionScheduler.java
@@ -28,7 +28,7 @@ public class AuctionScheduler {
   @Transactional
   public void runAuctionScheduler() {
     LocalDateTime now = LocalDateTime.now();
-    log.info("스케줄러 실행: {}", now);
+    log.info("⏱️스케줄러 실행: {}", now);
 
     openScheduledAuctions(now);
 
@@ -42,7 +42,7 @@ public class AuctionScheduler {
 
     for (Auction auction : startingAuctions) {
       auction.updateStatus(AuctionStatus.PROCESS);
-      log.info("경매 시작 처리 완료 ( 경매 ID: {}, 제목: {} )", auction.getId(), auction.getTitle());
+      log.info("✅경매 시작 처리 완료 ( 경매 ID: {}, 제목: {} )", auction.getId(), auction.getTitle());
     }
   }
 
@@ -58,17 +58,20 @@ public class AuctionScheduler {
         long targetPrice = auction.getStartPrice() - totalDiscount;
 
         if(targetPrice < auction.getStopLoss()) {
-          log.info("경매 유찰 ( 경매 ID: {}, StopLoss 도달)", auction.getId());
+          log.info("❌경매 유찰 ( 경매 ID: {}, StopLoss 도달)", auction.getId());
           auction.updateStatus(AuctionStatus.FAILED);
 
           auction.updateCurrentPrice(auction.getStopLoss());
         }
         else {
           if(targetPrice < auction.getCurrentPrice()) {
+            long oldPrice = auction.getCurrentPrice();
+
             auction.updateCurrentPrice(targetPrice);
             savePriceHistoryWithViewers(auction, targetPrice);
-            log.info("경매 가격 하락 처리 완료 ( 경매 ID: {}, 가격: {} -> {}",
-                auction.getId(), auction.getCurrentPrice(), targetPrice);
+
+            log.info("📉경매 가격 하락 처리 완료 ( 경매 ID: {}, 가격: {} -> {}",
+                auction.getId(), oldPrice, targetPrice);
           }
         }
       }

--- a/src/main/java/com/windfall/api/auction/service/AuctionSchedulerService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionSchedulerService.java
@@ -1,0 +1,81 @@
+package com.windfall.api.auction.service;
+
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.entity.AuctionPriceHistory;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import com.windfall.domain.auction.repository.AuctionPriceHistoryRepository;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuctionSchedulerService {
+
+  private final AuctionPriceHistoryRepository historyRepository;
+  private final AuctionRepository auctionRepository;
+  private final RedisTemplate<String, String> redisTemplate;
+
+  public void openScheduledAuctions(LocalDateTime now) {
+    List<Auction> startingAuctions = auctionRepository.findAllByStatusAndStartedAtLessThanEqual(
+        AuctionStatus.SCHEDULED, now
+    );
+
+    for (Auction auction : startingAuctions) {
+      auction.updateStatus(AuctionStatus.PROCESS);
+      log.info("✅경매 시작 처리 완료 ( 경매 ID: {}, 제목: {} )", auction.getId(), auction.getTitle());
+    }
+  }
+
+  public void dropAuctionPrices(LocalDateTime now) {
+    List<Auction> activeAuctions = auctionRepository.findAllByStatus(AuctionStatus.PROCESS);
+
+    for(Auction auction : activeAuctions) {
+      long minutesElapsed = java.time.Duration.between(auction.getStartedAt(), now).toMinutes();
+      long dropCount = minutesElapsed / 5;
+
+      if(dropCount > 0) {
+        long totalDiscount = dropCount * auction.getDropAmount();
+        long targetPrice = auction.getStartPrice() - totalDiscount;
+
+        if(targetPrice < auction.getStopLoss()) {
+          log.info("❌경매 유찰 ( 경매 ID: {}, StopLoss 도달)", auction.getId());
+          auction.updateStatus(AuctionStatus.FAILED);
+
+          auction.updateCurrentPrice(auction.getStopLoss());
+          savePriceHistoryWithViewers(auction, auction.getStopLoss());
+        }
+        else {
+          if(targetPrice < auction.getCurrentPrice()) {
+            long oldPrice = auction.getCurrentPrice();
+
+            auction.updateCurrentPrice(targetPrice);
+            savePriceHistoryWithViewers(auction, targetPrice);
+
+            log.info("📉경매 가격 하락 처리 완료 ( 경매 ID: {}, 가격: {} -> {}",
+                auction.getId(), oldPrice, targetPrice);
+          }
+        }
+      }
+    }
+  }
+
+  private void savePriceHistoryWithViewers(Auction auction, long targetPrice) {
+    String redisKey = "auction:" + auction.getId() + ":viewers";
+
+    Long viewerCount = redisTemplate.opsForSet().size(redisKey);
+    if (viewerCount == null) {
+      viewerCount = 0L;
+    }
+
+    AuctionPriceHistory history = AuctionPriceHistory.create(auction, targetPrice, viewerCount);
+    historyRepository.save(history);
+  }
+}

--- a/src/main/java/com/windfall/api/auction/service/AuctionService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionService.java
@@ -108,17 +108,15 @@ public class AuctionService {
 
     Auction auction = getAuctionById(auctionId);
 
-    Long displayPrice = auction.getDisplayPrice();
+    long displayPrice = auction.getDisplayPrice();
 
-    Double discountRate = null;
+    double discountRate = 0.0;
     if(auction.getStatus() != AuctionStatus.SCHEDULED) {
       discountRate = auction.calculateDiscountRate();
     }
 
-    boolean isSeller = auction.isSeller(userId);
-
-    Long exposedStopLoss = null;
-    if (isSeller) {
+    long exposedStopLoss = 0L;
+    if (auction.isSeller(userId)) {
       exposedStopLoss = auction.getStopLoss();
     }
 

--- a/src/main/java/com/windfall/domain/auction/entity/Auction.java
+++ b/src/main/java/com/windfall/domain/auction/entity/Auction.java
@@ -76,6 +76,10 @@ public class Auction extends BaseEntity {
     this.status = status;
   }
 
+  public void updateCurrentPrice(Long price) {
+    this.currentPrice = price;
+  }
+
   public long getDisplayPrice() {
     if (this.status == AuctionStatus.SCHEDULED) {
       return this.startPrice;

--- a/src/main/java/com/windfall/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/windfall/domain/auction/repository/AuctionRepository.java
@@ -1,8 +1,14 @@
 package com.windfall.domain.auction.repository;
 
 import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuctionRepository extends JpaRepository<Auction,Long> {
 
+  List<Auction> findAllByStatusAndStartedAtLessThanEqual(AuctionStatus status, LocalDateTime now);
+
+  List<Auction> findAllByStatus(AuctionStatus status);
 }

--- a/src/main/java/com/windfall/global/config/SchedulerConfig.java
+++ b/src/main/java/com/windfall/global/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.windfall.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #36 

## 📝 변경 사항
### AS-IS
- 자동 경매 상태 변경 및 가격 하락 기능 부재 (정적인 데이터 상태)
- 가격 변동 내역(`AuctionPriceHistory`)이 쌓이지 않아 그래프 데이터 제공 할 수 없음

### TO-BE
- `AuctionScheduler` 구현: 매 5분마다 실행되며 경매의 상태와 가격 업데이트

- 단순 차감 방식이 아닌 경과 시간 기반 계산 방식으로, 정확한 회차만큼의 가격 하락을 보장

- 가격이 변동되는 시점의 Redis 접속자 수를 스냅샷으로 떠서 DB에 함께 저장

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 테스트 시 시간을 조정하며 테스트 진행
    - `경매 시작` > `가격 하락` > `유찰 `과정 진행하도록 조작
<img width="738" height="78" alt="image" src="https://github.com/user-attachments/assets/3cd72f32-553c-4894-934f-3b2f08deb3c8" />

<img width="946" height="92" alt="image" src="https://github.com/user-attachments/assets/079baa19-936c-4bdf-b076-127b72c22477" />

<img width="1002" height="66" alt="image" src="https://github.com/user-attachments/assets/c46cb381-a0b7-43d5-8b6f-b9000f680890" />

<img width="774" height="84" alt="image" src="https://github.com/user-attachments/assets/f270fd91-8ce9-4573-9d7f-76404ff8e998" />

- 레디스의 접속자 수 가져옴
<img width="2586" height="632" alt="image" src="https://github.com/user-attachments/assets/696d58fb-3552-483d-8569-bb6ded2243bc" />
<img width="1158" height="1020" alt="image" src="https://github.com/user-attachments/assets/fea96602-6552-4435-a6ad-e22879e1a26a" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
현재는 트래픽이 많지 않으므로 스케줄러만 도입한 상태입니다. 추후에 성능 개선하도록 하겠습니다 !

> 경매에만 사용하는 스케줄러이므로 global 패키지에 두지 않았습니다. 좋은 의견 있으면 남겨주세요 

> `auction.updateCurrentPrice(auction.getStopLoss());`
> 해당 부분은 StopLoss 도달 전 유찰 됐을 때 마지막 가격을 StopLoss로 할지 아니면 그냥 가격으로 보일지 고민하다 넣었습니다! 
> 이것도 좋은 의견 있으면 남겨주세요