### PR TITLE
[Feature] OAuth 로그인 기능 구현 뼈대 완료

### DIFF
--- a/.github/workflows/CI_Test.yml
+++ b/.github/workflows/CI_Test.yml
@@ -6,10 +6,6 @@ on:
       - main
       - develop
 
-defaults:
-  run:
-    working-directory: backend
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI_Test.yml
+++ b/.github/workflows/CI_Test.yml
@@ -4,14 +4,26 @@ on:
   pull_request:
     branches:
       - main
-      - develop
+      - feature/*
+      - fix/*
+      - refactor/*
+    paths: 'backend/**'
+
+defaults:
+  run:
+    working-directory: backend
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-#    env:
-
+    env:
+      REST_API_KAKAO: ${{secrets.REST_API_KAKAO}}
+      REDIRECT_URI_KAKAO: ${{secrets.REDIRECT_URI_KAKAO}}
+      CLIENT_ID_NAVER: ${{secrets.CLIENT_ID_NAVER}}
+      REDIRECT_URI_NAVER: ${{secrets.REDIRECT_URI_NAVER}}
+      CLIENT_ID_GOOGLE: ${{secrets.CLIENT_ID_GOOGLE}}
+      REDIRECT_URI_GOOGLE: ${{secrets.REDIRECT_URI_GOOGLE}}
 
     steps:
       - name: 리포지토리를 가져옵니다

--- a/.github/workflows/CI_Test.yml
+++ b/.github/workflows/CI_Test.yml
@@ -4,10 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - feature/*
-      - fix/*
-      - refactor/*
-    paths: 'backend/**'
+      - develop
 
 defaults:
   run:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,12 @@ dependencies {
 
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+    // JWT
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+// JSON 파싱
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/windfall/api/user/controller/OAuthCallbackController.java
+++ b/src/main/java/com/windfall/api/user/controller/OAuthCallbackController.java
@@ -1,0 +1,91 @@
+//
+// OAuthCallbackController.java
+// 이 컨트롤러는 유저에게 실제 로그인을 담당합니다.
+// 이 파일은 아래와 같은 구조로 이루어져 있습니다.
+//   1. 각 provider에 맞는 서비스 객체 선언.
+//   2. 카카오로 회원가입/로그인하는 것을 담당하는 컨트롤러.
+//   3. 네이버로 회원가입/로그인하는 것을 담당하는 컨트롤러.
+//   4. 구글로 회원가입/로그인하는 것을 담당하는 컨트롤러.
+// provider란?: 카카오, 구글, 네이버 등 리소스 서버(연동사)를 지칭하는 말.
+
+package com.windfall.api.user.controller;
+
+import com.windfall.api.user.dto.response.LoginUserResponse;
+import com.windfall.api.user.service.OAuthGoogleService;
+import com.windfall.api.user.service.OAuthKakaoService;
+import com.windfall.api.user.service.OAuthNaverService;
+import com.windfall.global.response.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth/callback")
+@RequiredArgsConstructor
+public class OAuthCallbackController implements OAuthCallbackSpecification{
+
+  //   1. 각 provider에 맞는 서비스 객체 선언.
+  private final OAuthKakaoService kakaoService;
+  private final OAuthNaverService naverService;
+  private final OAuthGoogleService googleService;
+
+
+  //   2. 카카오로 회원가입/로그인하는 것을 담당하는 컨트롤러
+  @GetMapping("/kakao")
+  public ApiResponse<LoginUserResponse> kakaoCallback(
+      @RequestParam String code, HttpServletResponse response
+  ) {
+    // kakaoService에서 code로 access token 요청, 사용자 정보 가져오기
+    LoginUserResponse loginUserResponse = kakaoService.loginOrSignup(code);
+    response.addCookie(generateCookieWithAccessToken());
+    response.addCookie(generateCookieWithRefreshToken());
+    return ApiResponse.ok("카카오 로그인 성공", loginUserResponse);
+  }
+
+  //   3. 네이버로 회원가입/로그인하는 것을 담당하는 컨트롤러
+  @GetMapping("/naver")
+  public ApiResponse<LoginUserResponse> naverCallback(
+      @RequestParam String code, HttpServletResponse response
+  ) {
+    // naverService에서 code로 access token 요청, 사용자 정보 가져오기
+    LoginUserResponse loginUserResponse = naverService.loginOrSignup(code);
+    response.addCookie(generateCookieWithAccessToken());
+    response.addCookie(generateCookieWithRefreshToken());
+    return ApiResponse.ok("네이버 로그인 성공", loginUserResponse);
+  }
+
+  //   4. 구글로 회원가입/로그인하는 것을 담당하는 컨트롤러
+  @GetMapping("/google")
+  public ApiResponse<LoginUserResponse> googleCallback(
+      @RequestParam String code, HttpServletResponse response
+  ) {
+    // googleService에서 code로 access token 요청, 사용자 정보 가져오기
+    LoginUserResponse loginUserResponse = googleService.loginOrSignup(code);
+    response.addCookie(generateCookieWithAccessToken());
+    response.addCookie(generateCookieWithRefreshToken());
+    return ApiResponse.ok("구글 로그인 성공", loginUserResponse);
+  }
+
+  private Cookie generateCookieWithAccessToken() {
+    Cookie accessTokenCookie = new Cookie("accessToken", "accessToken");
+    accessTokenCookie.setHttpOnly(true);
+    accessTokenCookie.setSecure(true);
+    accessTokenCookie.setPath("/");
+    accessTokenCookie.setMaxAge(1 * 1 * 60 * 60); // 1시간
+    return accessTokenCookie;
+  }
+
+  private Cookie generateCookieWithRefreshToken() {
+    Cookie refreshTokenCookie = new Cookie("refreshToken", "accessToken");
+    refreshTokenCookie.setHttpOnly(true);
+    refreshTokenCookie.setSecure(true);
+    refreshTokenCookie.setPath("/");
+    refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60); // 7일 (일주일)
+    return refreshTokenCookie;
+  }
+
+}

--- a/src/main/java/com/windfall/api/user/controller/OAuthCallbackSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/OAuthCallbackSpecification.java
@@ -1,0 +1,22 @@
+//
+// OAuthCallbackSpecification 인터페이스는 OAuthCallbackController 클래스의 Swagger 설명문을 담당합니다.
+
+package com.windfall.api.user.controller;
+
+import com.windfall.api.user.dto.response.LoginUserResponse;
+import com.windfall.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface OAuthCallbackSpecification {
+
+  @Operation(summary = "카카오 로그인 콜백 요청", description = "카카오로 로그인합니다.")
+  ApiResponse<LoginUserResponse> kakaoCallback(@RequestParam String code, HttpServletResponse response);
+
+  @Operation(summary = "네이버 로그인 콜백 요청", description = "네이버로 로그인합니다.")
+  ApiResponse<LoginUserResponse> naverCallback(@RequestParam String code, HttpServletResponse response);
+
+  @Operation(summary = "구글 로그인 콜백 요청", description = "구글로 로그인합니다.")
+  ApiResponse<LoginUserResponse> googleCallback(@RequestParam String code, HttpServletResponse response);
+}

--- a/src/main/java/com/windfall/api/user/controller/UserController.java
+++ b/src/main/java/com/windfall/api/user/controller/UserController.java
@@ -1,10 +1,24 @@
 //
-// 구체적으로 필요한 함수는 다음 PR 때 적겠습니다.
+// UserController.java
+// 이 파일은 사용자의 OAuth 로그인 시작을 담당합니다.
+// 이 파일은 아래와 같은 구조로 이루어져 있습니다.
+//   1. 로그인 화면 요청 url에 필요한 값들을 application.yml에서 가져옵니다.
+//   2. 로그인 화면 요청 url에 쓸 변수를 선언합니다.
+//   3. init()함수로 로그인 화면 요청 url을 조합합니다.
+//   4. redirectToLogin 함수에서 provider에 맞는 url을 반환합니다.
+//   5. 이를 통해 사용자는 provider에 맞는 로그인 페이지로 이동합니다.
+// provider란?: 카카오, 구글, 네이버 등 리소스 서버(연동사)를 지칭하는 말.
+
 package com.windfall.api.user.controller;
 
 import com.windfall.api.user.service.UserService;
+import com.windfall.global.response.ApiResponse;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,4 +27,59 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserSpecification {
 
   private final UserService userService;
+
+  // 1. 로그인 화면 요청 url에 필요한 값들. application.yml 참고.
+  @Value("${spring.kakao.client.id}")
+  private String kakaoRestApiKey;
+  @Value("${spring.kakao.redirect.uri}")
+  private String kakaoRedirectUri;
+
+  @Value("${spring.naver.client.id}")
+  private String naverClientId;
+  @Value("${spring.naver.redirect.uri}")
+  private String naverRedirectUri;
+
+  @Value("${spring.google.client.id}")
+  private String googleClientId;
+  @Value("${spring.google.redirect.uri}")
+  private String googleRedirectUri;
+
+  // 2. 로그인 화면 요청 url String.
+  private String URL_KAKAO = "";
+  private String URL_NAVER = "";
+  private String URL_GOOGLE = "";
+  private String URL_WRONG = "";
+
+  // 3. url String을 @Value 주입 후에 실행되게 함.
+  @PostConstruct
+  private void init() {
+    URL_KAKAO = "https://kauth.kakao.com/oauth/authorize"
+        + "?client_id=" + kakaoRestApiKey
+        + "&redirect_uri=" + kakaoRedirectUri
+        + "&response_type=code";
+
+    URL_NAVER = "https://nid.naver.com/oauth2.0/authorize"
+        + "?client_id=" + naverClientId
+        + "&redirect_uri=" + naverRedirectUri
+        + "&response_type=code";
+
+    URL_GOOGLE = "https://accounts.google.com/o/oauth2/v2/auth"
+        + "?client_id=" + googleClientId
+        + "&redirect_uri=" + googleRedirectUri
+        + "&response_type=code"
+        + "&scope=openid%20email%20profile";
+  }
+
+  // 4. 로그인 화면 요청과 반환하는 컨트롤러
+  @GetMapping("/auth")
+  public ApiResponse<String> redirectToLogin(@RequestParam String provider) {
+
+    return switch (provider.toLowerCase()) {
+      case "kakao" -> ApiResponse.ok(provider + " 로그인 페이지.", URL_KAKAO);
+      case "naver" -> ApiResponse.ok(provider + " 로그인 페이지.", URL_NAVER);
+      case "google" -> ApiResponse.ok(provider + " 로그인 페이지.", URL_GOOGLE);
+      default -> ApiResponse.ok(provider + "는 잘못된 provider입니다.", URL_WRONG);
+    };
+  }
+
 }

--- a/src/main/java/com/windfall/api/user/controller/UserSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/UserSpecification.java
@@ -1,9 +1,16 @@
 //
-// 구체적으로 필요한 함수와 Swagger는 다음 PR 때 적겠습니다.
+// UserSpecification 인터페이스는 UserController 클래스의 Swagger 설명문을 담당합니다.
+
 package com.windfall.api.user.controller;
 
+import com.windfall.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "User", description = "사용자 API")
 public interface UserSpecification {
+
+  @Operation(summary = "로그인 URL 반환", description = "provier에 맞는 로그인 url을 반환합니다.")
+  ApiResponse<String> redirectToLogin(@RequestParam String provider);
 }

--- a/src/main/java/com/windfall/api/user/dto/LoginUserRequest.java
+++ b/src/main/java/com/windfall/api/user/dto/LoginUserRequest.java
@@ -1,4 +1,0 @@
-package com.windfall.api.user.dto;
-
-public class LoginUserRequest {
-}

--- a/src/main/java/com/windfall/api/user/dto/LoginUserResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/LoginUserResponse.java
@@ -1,4 +1,0 @@
-package com.windfall.api.user.dto;
-
-public class LoginUserResponse {
-}

--- a/src/main/java/com/windfall/api/user/dto/RegisterUserRequest.java
+++ b/src/main/java/com/windfall/api/user/dto/RegisterUserRequest.java
@@ -1,4 +1,0 @@
-package com.windfall.api.user.dto;
-
-public class RegisterUserRequest {
-}

--- a/src/main/java/com/windfall/api/user/dto/RegisterUserResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/RegisterUserResponse.java
@@ -1,4 +1,0 @@
-package com.windfall.api.user.dto;
-
-public class RegisterUserResponse {
-}

--- a/src/main/java/com/windfall/api/user/dto/request/LoginUserRequest.java
+++ b/src/main/java/com/windfall/api/user/dto/request/LoginUserRequest.java
@@ -1,0 +1,4 @@
+package com.windfall.api.user.dto.request;
+
+public class LoginUserRequest {
+}

--- a/src/main/java/com/windfall/api/user/dto/request/RegisterUserRequest.java
+++ b/src/main/java/com/windfall/api/user/dto/request/RegisterUserRequest.java
@@ -1,0 +1,4 @@
+package com.windfall.api.user.dto.request;
+
+public class RegisterUserRequest {
+}

--- a/src/main/java/com/windfall/api/user/dto/response/LoginUserResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/LoginUserResponse.java
@@ -1,0 +1,8 @@
+package com.windfall.api.user.dto.response;
+
+// 로그인 응답 DTO
+public record LoginUserResponse(
+    String userId,
+    String username,
+    String userProfileUrl
+) {}

--- a/src/main/java/com/windfall/api/user/dto/response/OAuthUserInfo.java
+++ b/src/main/java/com/windfall/api/user/dto/response/OAuthUserInfo.java
@@ -1,0 +1,10 @@
+//
+
+package com.windfall.api.user.dto.response;
+
+// 공통 사용자 정보 DTO
+public record OAuthUserInfo(
+    String email,
+    String nickname,
+    String profileImageUrl
+) {}

--- a/src/main/java/com/windfall/api/user/dto/response/RegisterUserResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/RegisterUserResponse.java
@@ -1,0 +1,4 @@
+package com.windfall.api.user.dto.response;
+
+public class RegisterUserResponse {
+}

--- a/src/main/java/com/windfall/api/user/service/JwtService.java
+++ b/src/main/java/com/windfall/api/user/service/JwtService.java
@@ -1,0 +1,56 @@
+package com.windfall.api.user.service;
+
+import com.windfall.domain.user.entity.User;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+
+  private final String secretKey = "JWT_SECRET_KEY"; // application.yml에서 관리 가능
+  private final long accessTokenValidity = 3600_000; // 1시간
+  private final long refreshTokenValidity = 604_800_000; // 7일
+
+  // Access Token 생성
+  public String generateAccessToken(User member) {
+    return Jwts.builder()
+        .setSubject(member.getProviderUserId())
+        .claim("username", "")
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidity))
+        .signWith(SignatureAlgorithm.HS256, secretKey)
+        .compact();
+  }
+
+  // Refresh Token 생성
+  public String generateRefreshToken(User member) {
+    return Jwts.builder()
+        .setSubject(member.getProviderUserId())
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidity))
+        .signWith(SignatureAlgorithm.HS256, secretKey)
+        .compact();
+  }
+
+  // JWT 검증
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+      return true;
+    } catch (JwtException e) {
+      return false;
+    }
+  }
+
+  // JWT에서 사용자 ID 추출
+  public String getUserId(String token) {
+    return Jwts.parser()
+        .setSigningKey(secretKey)
+        .parseClaimsJws(token)
+        .getBody()
+        .getSubject();
+  }
+}

--- a/src/main/java/com/windfall/api/user/service/OAuthGoogleService.java
+++ b/src/main/java/com/windfall/api/user/service/OAuthGoogleService.java
@@ -1,0 +1,65 @@
+// OAuthKakaoService, OAuthNaverService, OAuthGoogleService가 겹치는 것은 추후 리팩토링 때 정리하겠습니다.
+// 각 provider 회사마다 나눈 이유는, 각 회사가 전달하는 데이터 로직이 (미래를 고려해) 미묘하게 달라질 수 있다고 하기 때문입니다.
+// 연관 파일
+//   RestTemplateConfig.java
+
+package com.windfall.api.user.service;
+
+import com.windfall.api.user.dto.response.LoginUserResponse;
+import com.windfall.api.user.dto.response.OAuthUserInfo;
+import com.windfall.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthGoogleService {
+  private final UserRepository memberRepository;
+  //private final JwtService jwtService; // JWT 발급용
+  private final RestTemplate restTemplate;
+
+  @Value("${spring.kakao.client.id}")
+  private String kakaoClientId;
+
+  @Value("${spring.kakao.redirect.uri}")
+  private String kakaoRedirectUri;
+
+  public LoginUserResponse loginOrSignup(String code) {
+    // 1. code로 access token 발급
+    String accessToken = requestAccessToken(code);
+
+    // 2. access token으로 사용자 정보 요청
+    OAuthUserInfo userInfo = requestUserInfo(accessToken);
+
+    // 3. DB에서 회원 확인 후 없으면 생성
+    /*
+    User member = memberRepository.findByEmail(userInfo.email())
+        .orElseGet(() -> memberRepository.save(
+            new User(userInfo.email(), userInfo.nickname(), userInfo.profileImageUrl())
+        ));
+     */
+
+    // 4. JWT 발급
+    //String jwtAccessToken = jwtService.generateAccessToken(member);
+    //String jwtRefreshToken = jwtService.generateRefreshToken(member);
+    String jwtAccessToken = "";
+    String jwtRefreshToken = "";
+
+    return new LoginUserResponse("","","");
+    //return new LoginUserResponse(member.getUserId(), member.getUsername(), jwtAccessToken, jwtRefreshToken);
+  }
+
+  private String requestAccessToken(String code) {
+    // RestTemplate 사용, 카카오 API에 POST 요청
+    // 반환값은 access token
+    return "";
+  }
+
+  private OAuthUserInfo requestUserInfo(String accessToken) {
+    // RestTemplate 사용, 카카오 API에 GET 요청
+    // JSON 응답 → OAuthUserInfo로 변환
+    return new OAuthUserInfo("", "", "");
+  }
+}

--- a/src/main/java/com/windfall/api/user/service/OAuthGoogleService.java
+++ b/src/main/java/com/windfall/api/user/service/OAuthGoogleService.java
@@ -20,11 +20,11 @@ public class OAuthGoogleService {
   //private final JwtService jwtService; // JWT 발급용
   private final RestTemplate restTemplate;
 
-  @Value("${spring.kakao.client.id}")
-  private String kakaoClientId;
+  @Value("${spring.google.client.id}")
+  private String googleClientId;
 
-  @Value("${spring.kakao.redirect.uri}")
-  private String kakaoRedirectUri;
+  @Value("${spring.google.redirect.uri}")
+  private String googleRedirectUri;
 
   public LoginUserResponse loginOrSignup(String code) {
     // 1. code로 access token 발급

--- a/src/main/java/com/windfall/api/user/service/OAuthKakaoService.java
+++ b/src/main/java/com/windfall/api/user/service/OAuthKakaoService.java
@@ -1,0 +1,65 @@
+// OAuthKakaoService, OAuthNaverService, OAuthGoogleService가 겹치는 것은 추후 리팩토링 때 정리하겠습니다.
+// 각 provider 회사마다 나눈 이유는, 각 회사가 전달하는 데이터 로직이 (미래를 고려해) 미묘하게 달라질 수 있다고 하기 때문입니다.
+// 연관 파일
+//   RestTemplateConfig.java
+
+package com.windfall.api.user.service;
+
+import com.windfall.api.user.dto.response.LoginUserResponse;
+import com.windfall.api.user.dto.response.OAuthUserInfo;
+import com.windfall.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthKakaoService {
+  private final UserRepository memberRepository;
+  private final JwtService jwtService; // JWT 발급용
+  private final RestTemplate restTemplate;
+
+  @Value("${spring.kakao.client.id}")
+  private String kakaoClientId;
+
+  @Value("${spring.kakao.redirect.uri}")
+  private String kakaoRedirectUri;
+
+  public LoginUserResponse loginOrSignup(String code) {
+    // 1. code로 access token 발급
+    String accessToken = requestAccessToken(code);
+
+    // 2. access token으로 사용자 정보 요청
+    OAuthUserInfo userInfo = requestUserInfo(accessToken);
+
+    // 3. DB에서 회원 확인 후 없으면 생성
+    /*
+    User member = memberRepository.findByEmail(userInfo.email())
+        .orElseGet(() -> memberRepository.save(
+            new User(userInfo.email(), userInfo.nickname(), userInfo.profileImageUrl())
+        ));
+     */
+
+    // 4. JWT 발급
+    //String jwtAccessToken = jwtService.generateAccessToken(member);
+    //String jwtRefreshToken = jwtService.generateRefreshToken(member);
+    String jwtAccessToken = "";
+    String jwtRefreshToken = "";
+
+    return new LoginUserResponse("", "","");
+    //return new LoginUserResponse(member.getUserId(), member.getUsername(), jwtAccessToken, jwtRefreshToken);
+  }
+
+  private String requestAccessToken(String code) {
+    // RestTemplate 사용, 카카오 API에 POST 요청
+    // 반환값은 access token
+    return "";
+  }
+
+  private OAuthUserInfo requestUserInfo(String accessToken) {
+    // RestTemplate 사용, 카카오 API에 GET 요청
+    // JSON 응답 → OAuthUserInfo로 변환
+    return new OAuthUserInfo("", "", "");
+  }
+}

--- a/src/main/java/com/windfall/api/user/service/OAuthNaverService.java
+++ b/src/main/java/com/windfall/api/user/service/OAuthNaverService.java
@@ -20,11 +20,11 @@ public class OAuthNaverService {
   //private final JwtService jwtService; // JWT 발급용
   private final RestTemplate restTemplate;
 
-  @Value("${spring.kakao.client.id}")
-  private String kakaoClientId;
+  @Value("${spring.naver.client.id}")
+  private String naverClientId;
 
-  @Value("${spring.kakao.redirect.uri}")
-  private String kakaoRedirectUri;
+  @Value("${spring.naver.redirect.uri}")
+  private String naverRedirectUri;
 
   public LoginUserResponse loginOrSignup(String code) {
     // 1. code로 access token 발급

--- a/src/main/java/com/windfall/api/user/service/OAuthNaverService.java
+++ b/src/main/java/com/windfall/api/user/service/OAuthNaverService.java
@@ -1,0 +1,65 @@
+// OAuthKakaoService, OAuthNaverService, OAuthGoogleService가 겹치는 것은 추후 리팩토링 때 정리하겠습니다.
+// 각 provider 회사마다 나눈 이유는, 각 회사가 전달하는 데이터 로직이 (미래를 고려해) 미묘하게 달라질 수 있다고 하기 때문입니다.
+// 연관 파일
+//   RestTemplateConfig.java
+
+package com.windfall.api.user.service;
+
+import com.windfall.api.user.dto.response.LoginUserResponse;
+import com.windfall.api.user.dto.response.OAuthUserInfo;
+import com.windfall.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthNaverService {
+  private final UserRepository memberRepository;
+  //private final JwtService jwtService; // JWT 발급용
+  private final RestTemplate restTemplate;
+
+  @Value("${spring.kakao.client.id}")
+  private String kakaoClientId;
+
+  @Value("${spring.kakao.redirect.uri}")
+  private String kakaoRedirectUri;
+
+  public LoginUserResponse loginOrSignup(String code) {
+    // 1. code로 access token 발급
+    String accessToken = requestAccessToken(code);
+
+    // 2. access token으로 사용자 정보 요청
+    OAuthUserInfo userInfo = requestUserInfo(accessToken);
+
+    // 3. DB에서 회원 확인 후 없으면 생성
+    /*
+    User member = memberRepository.findByEmail(userInfo.email())
+        .orElseGet(() -> memberRepository.save(
+            new User(userInfo.email(), userInfo.nickname(), userInfo.profileImageUrl())
+        ));
+     */
+
+    // 4. JWT 발급
+    //String jwtAccessToken = jwtService.generateAccessToken(member);
+    //String jwtRefreshToken = jwtService.generateRefreshToken(member);
+    String jwtAccessToken = "";
+    String jwtRefreshToken = "";
+
+    return new LoginUserResponse("","","");
+    //return new LoginUserResponse(member.getUserId(), member.getUsername(), jwtAccessToken, jwtRefreshToken);
+  }
+
+  private String requestAccessToken(String code) {
+    // RestTemplate 사용, 카카오 API에 POST 요청
+    // 반환값은 access token
+    return "";
+  }
+
+  private OAuthUserInfo requestUserInfo(String accessToken) {
+    // RestTemplate 사용, 카카오 API에 GET 요청
+    // JSON 응답 → OAuthUserInfo로 변환
+    return new OAuthUserInfo("", "", "");
+  }
+}

--- a/src/main/java/com/windfall/api/user/service/RestTemplateConfig.java
+++ b/src/main/java/com/windfall/api/user/service/RestTemplateConfig.java
@@ -1,0 +1,17 @@
+// RestTemplateConfig는 RestTemplate을 의존성 주입 가능한 빈으로 만듭니다.
+// RestTemplate 타입 객체는 OAuthKakaoService, OAuthNaverService, OAuthGoogleService에서 사용됩니다.
+
+package com.windfall.api.user.service;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/com/windfall/domain/profile/entity/Profile.java
+++ b/src/main/java/com/windfall/domain/profile/entity/Profile.java
@@ -1,0 +1,40 @@
+package com.windfall.domain.profile.entity;
+
+import com.windfall.domain.user.entity.User;
+import com.windfall.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Profile extends BaseEntity {
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @Column(nullable = false)
+  private String email;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false, name = "profile_image_url")
+  private String profileImageUrl;
+
+  @Builder
+  public Profile(User user, String email, String name, String profileImageUrl) {
+    this.user = user;
+    this.email = email;
+    this.name = name;
+    this.profileImageUrl = profileImageUrl;
+  }
+}

--- a/src/main/java/com/windfall/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/windfall/global/config/RestTemplateConfig.java
@@ -1,7 +1,7 @@
 // RestTemplateConfig는 RestTemplate을 의존성 주입 가능한 빈으로 만듭니다.
 // RestTemplate 타입 객체는 OAuthKakaoService, OAuthNaverService, OAuthGoogleService에서 사용됩니다.
 
-package com.windfall.api.user.service;
+package com.windfall.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
   // 유저
   NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+  NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "해당 provider를 찾을 수 없습니다."),
 
   // 경매
   INVALID_TIME(HttpStatus.BAD_REQUEST, "경매 시간을 다시 설정해주세요."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,24 @@ spring:
       ddl-auto: update
     show-sql: true
 
+  kakao:
+    client:
+      id: ${REST_API_KAKAO}
+    redirect:
+      uri: ${REDIRECT_URI_KAKAO}
+
+  naver:
+    client:
+      id: ${CLIENT_ID_NAVER}
+    redirect:
+      uri: ${REDIRECT_URI_NAVER}
+
+  google:
+    client:
+      id: ${CLIENT_ID_GOOGLE}
+    redirect:
+      uri: ${REDIRECT_URI_GOOGLE}
+
 logging:
   level:
     org.hibernate.orm.jdbc.bind: TRACE

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,6 +11,23 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  kakao:
+    client:
+      id: ${REST_API_KAKAO}
+    redirect:
+      uri: ${REDIRECT_URI_KAKAO}
+
+  naver:
+    client:
+      id: ${CLIENT_ID_NAVER}
+    redirect:
+      uri: ${REDIRECT_URI_NAVER}
+
+  google:
+    client:
+      id: ${CLIENT_ID_GOOGLE}
+    redirect:
+      uri: ${REDIRECT_URI_GOOGLE}
 
   data:
     redis:


### PR DESCRIPTION
## 📌 관련 이슈
- close #12 

## 📝 변경 사항
### AS-IS
- OAuth 로그인 기능 부재

### TO-BE
- SWAGGER를 통해 확인 가능합니다.
- 1. 완성된 것
  - 카카오/네이버/구글을 통해 로그인 페이지 반환하는 로직
  - 콜백을 통한 회원가입/로그인에 대한 요청 응답
  - 응답에 쿠키 넣어 반환
- 2. 아직 미완인 것
  - 유저를 db에 저장하는 것.
  - 실제 jwt 토큰 값을 생성해서 전달하는 것.
  - 필터 체인 도입.
- 3. 주의점
  - application.yml에 환경변수 추가
  - gradle에 jwt 위해 의존성 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
### 카카오 
<img width="860" height="837" alt="로그인 url 요청 - 카카오" src="https://github.com/user-attachments/assets/1ae26108-1ff7-4626-b26a-b061283cf7bb" />
<img width="1730" height="791" alt="로그인 CALLBACK 요청 - 카카오" src="https://github.com/user-attachments/assets/e1cdb41d-5631-4517-a322-977b5fa02e07" />

### 네이버
<img width="751" height="642" alt="로그인 url 요청 - 네이버" src="https://github.com/user-attachments/assets/a9b51dd4-dc41-4056-b7a5-43c77ed81315" />
<img width="1235" height="742" alt="로그인 CALLBACK 요청 - 네이버" src="https://github.com/user-attachments/assets/79d2928b-021f-4200-b90e-7e0987af68c8" />

### 구글
<img width="952" height="412" alt="로그인 url 요청 - 구글" src="https://github.com/user-attachments/assets/f11b0269-3f03-4d40-95bf-d270430455b6" />
<img width="867" height="471" alt="로그인 CALLBACK 요청 - 구글" src="https://github.com/user-attachments/assets/751c08ff-da6f-4c1e-b453-22c26a253c3b" />

### 반환 쿠키
<img width="1841" height="402" alt="쿠키 반환" src="https://github.com/user-attachments/assets/02ff4540-2575-4da1-ac3c-de81b3a2bec4" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 작동 가능하게만 만들었습니다.
- 효율적인 코드 구조는 조언해주시면 리팩토링 때 개선하겠습니다.