### PR TITLE
[Feature] 유저 로그인 이후 기능 구현

### DIFF
--- a/src/main/java/com/windfall/api/user/controller/OAuthCallbackController.java
+++ b/src/main/java/com/windfall/api/user/controller/OAuthCallbackController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
 
 @RestController
 @RequestMapping("/api/v1/auth/callback")
@@ -37,7 +38,7 @@ public class OAuthCallbackController implements OAuthCallbackSpecification {
 
   //   2. 카카오로 회원가입/로그인하는 것을 담당하는 컨트롤러
   @GetMapping("/kakao")
-  public ApiResponse<LoginUserResponse> kakaoCallback(
+  public RedirectView kakaoCallback(
       @RequestParam String code, HttpServletResponse response
   ) {
     // kakaoService에서 code로 access token 요청, 사용자 정보 가져오기
@@ -49,7 +50,11 @@ public class OAuthCallbackController implements OAuthCallbackSpecification {
 
     response.addCookie(generateCookieWithAccessToken(registerUserResponse.accessToken()));
     response.addCookie(generateCookieWithRefreshToken(registerUserResponse.refreshToken()));
-    return ApiResponse.ok("카카오 로그인 성공", loginUserResponse);
+    //return ApiResponse.ok("카카오 로그인 성공", loginUserResponse);
+    RedirectView redirectView = new RedirectView();
+    redirectView.setUrl("http://localhost:3000");
+    redirectView.setExposeModelAttributes(false);
+    return redirectView;
   }
 
   //   3. 네이버로 회원가입/로그인하는 것을 담당하는 컨트롤러

--- a/src/main/java/com/windfall/api/user/controller/OAuthCallbackSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/OAuthCallbackSpecification.java
@@ -8,11 +8,12 @@ import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.view.RedirectView;
 
 public interface OAuthCallbackSpecification {
 
   @Operation(summary = "카카오 로그인 콜백 요청", description = "카카오로 로그인합니다. 한번 회원가입된 아이디로 다시 이 테스트를 하시면 KOE320 오류가 뜹니다. 대신 2번째 로그인부턴 바로 성공 결과가 뜹니다.")
-  ApiResponse<LoginUserResponse> kakaoCallback(@RequestParam String code, HttpServletResponse response);
+  RedirectView kakaoCallback(@RequestParam String code, HttpServletResponse response);
 
   @Operation(summary = "네이버 로그인 콜백 요청", description = "네이버로 로그인합니다.")
   ApiResponse<LoginUserResponse> naverCallback(@RequestParam String code, HttpServletResponse response);

--- a/src/main/java/com/windfall/api/user/controller/UserSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/UserSpecification.java
@@ -3,14 +3,22 @@
 
 package com.windfall.api.user.controller;
 
+import com.windfall.api.user.dto.response.LoginUserResponse;
 import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "User", description = "사용자 API")
 public interface UserSpecification {
 
-  @Operation(summary = "로그인 URL 반환", description = "provier에 맞는 로그인 url을 반환합니다.")
+  @Operation(summary = "로그인 URL 반환", description = "provider에 맞는 로그인 url을 반환합니다.")
   ApiResponse<String> redirectToLogin(@RequestParam String provider);
+
+  @Operation(summary = "로그인 이후 유저 기본 정보 반환",  description = "쿠키 속 액세스 토큰을 받고 해당 사용자에 맞는 이메일, 유저네임, 프로필url을 반환합니다.")
+  public ApiResponse<LoginUserResponse> returnBasicUserInfo(@CookieValue("accessToken") String accessToken);
+
+  @Operation(summary = "두 토큰 중 하나라도 사용 가능한가 true/false 반환", description = "쿠키 속 액세스 토큰과 리프레시 토큰 중 하나라도 사용 가능하면 true, 둘 다 만료되었으면 false 반환합니다.")
+  public ApiResponse<Boolean> validateTokens(@CookieValue("accessToken") String accessToken, @CookieValue("refreshToken") String refreshToken);
 }

--- a/src/main/java/com/windfall/api/user/dto/response/LoginUserResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/LoginUserResponse.java
@@ -3,6 +3,6 @@ package com.windfall.api.user.dto.response;
 // 로그인 응답 DTO
 public record LoginUserResponse(
     String userEmail,
-    String userNickname,
+    String username,
     String userProfileUrl
 ) {}

--- a/src/main/java/com/windfall/api/user/service/JwtProvider.java
+++ b/src/main/java/com/windfall/api/user/service/JwtProvider.java
@@ -1,16 +1,20 @@
 package com.windfall.api.user.service;
 
 import com.windfall.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class JwtProvider {
-  private final String secretKey;
+  private final Key key; // SecretKey로 변환
   private final long accessTokenValidity;
   private final long refreshTokenValidity;
 
@@ -19,7 +23,7 @@ public class JwtProvider {
       @Value("${custom.jwt.expireSecondsAccessToken}") long accessTokenValidity,
       @Value("${custom.jwt.expireSecondsRefreshToken}") long refreshTokenValidity
   ) {
-    this.secretKey = secretKey;
+    this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     this.accessTokenValidity = accessTokenValidity;
     this.refreshTokenValidity = refreshTokenValidity;
   }
@@ -31,7 +35,7 @@ public class JwtProvider {
         .claim(user.getProviderUserId(), "")
         .setIssuedAt(new Date())
         .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidity * 1000))
-        .signWith(SignatureAlgorithm.HS256, secretKey)
+        .signWith(key, SignatureAlgorithm.HS256)
         .compact();
   }
 
@@ -42,24 +46,43 @@ public class JwtProvider {
         .claim(user.getProviderUserId(), "")
         .setIssuedAt(new Date())
         .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidity * 1000))
-        .signWith(SignatureAlgorithm.HS256, secretKey)
+        .signWith(key, SignatureAlgorithm.HS256)
         .compact();
   }
 
   // JWT 검증
   public boolean validateToken(String token) {
     try {
-      Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
-      return true;
-    } catch (JwtException e) {
+      // JWT 파싱 (서명 검증 포함)
+      Claims claims = Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(token)
+          .getBody();
+
+      // 만료일(exp) 확인
+      Date expiration = claims.getExpiration();
+      if (expiration == null) {
+        // exp가 없으면 만료로 간주
+        System.out.println("토큰 검사했는데 만료 정보 없음, 비정상");
+        return false;
+      }
+
+      boolean notExpired = expiration.after(new Date());
+      System.out.println("토큰 검사했는데 " + (notExpired ? "정상입니다." : "만료되었습니다."));
+      return notExpired;
+
+    } catch (JwtException | IllegalArgumentException e) {
+      System.out.println("토큰 검사했는데 비정상입니다.");
       return false;
     }
   }
 
   // JWT에서 사용자 ID 추출
-  public String getUserId(String token) {
-    return Jwts.parser()
-        .setSigningKey(secretKey)
+  public String getProviderUserId(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
         .parseClaimsJws(token)
         .getBody()
         .getSubject();

--- a/src/main/java/com/windfall/api/user/service/JwtProvider.java
+++ b/src/main/java/com/windfall/api/user/service/JwtProvider.java
@@ -64,16 +64,13 @@ public class JwtProvider {
       Date expiration = claims.getExpiration();
       if (expiration == null) {
         // exp가 없으면 만료로 간주
-        System.out.println("토큰 검사했는데 만료 정보 없음, 비정상");
         return false;
       }
 
       boolean notExpired = expiration.after(new Date());
-      System.out.println("토큰 검사했는데 " + (notExpired ? "정상입니다." : "만료되었습니다."));
       return notExpired;
 
     } catch (JwtException | IllegalArgumentException e) {
-      System.out.println("토큰 검사했는데 비정상입니다.");
       return false;
     }
   }

--- a/src/main/java/com/windfall/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/windfall/global/security/CustomAuthenticationFilter.java
@@ -72,7 +72,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
     }
 
     // 4. 사용자 정보 가져오기
-    String providerUserId = jwtProvider.getUserId(token);
+    String providerUserId = jwtProvider.getProviderUserId(token);
     User user = userService.getUserByProviderUserId(providerUserId);
     UserDetails userDetails = org.springframework.security.core.userdetails.User
         .withUsername(user.getProviderUserId())


### PR DESCRIPTION

## 📌 관련 이슈
- close #51
## 📝 변경 사항
### AS-IS
- 로그인 성공 시 localhost 8080에 json으로 유저네임, 이메일, 프로필 url 반환함.
- 토큰 만료 체크 기능 부재.

### TO-BE
- 로그인 성공 시 localhost 3000으로 리다이렉트하는 기능
- 로그인 이후 액세스토큰으로 유저네임, 이메일, 프로필 url 요청 시 반환하는 기능.
- 로그인 이후 액세스 토큰과 리프레시 토큰 둘 다 만료되면 체크해서 false 반환하는 기능.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
### 리다이렉트 3000
<img width="1116" height="716" alt="20251217 리다이렉트 결과" src="https://github.com/user-attachments/assets/0ccd6c0d-5fa1-4267-ab82-77c7b534dc54" />

### 액세스토큰으로 유저네임, 이메일, 프로필 url 요청 시 반환
<img width="1765" height="873" alt="20251217 액세스토큰 값 받아서 기본 정보 반환 (유저네임이라고 바꾼 것도 포함)" src="https://github.com/user-attachments/assets/04799160-5207-4e89-8a7e-428295aa5569" />

### 토큰 검사 (토큰 값 바꿀 때 f12 눌러서 직접 값 변경해야 합니다. 화면에 토큰 값은 아무 거나 넣어도 되는 것 같습니다.)
- 둘 다 정상
<img width="1777" height="885" alt="20251217 토큰 검사 - 둘 다 정상" src="https://github.com/user-attachments/assets/c79ef8a6-30a1-471f-97b8-8ea24476cbe3" />

- 액세스 토큰 비정상
<img width="1672" height="873" alt="20251217 토큰 검사 - 액세스토큰 비정상" src="https://github.com/user-attachments/assets/2f67993d-a02c-4ab4-b69a-5df70dc309a0" />

- 리프레시 토큰 비정상
<img width="1502" height="877" alt="20251217 토큰 검사 - 리프레시토큰 비정상" src="https://github.com/user-attachments/assets/7455887b-b30d-49bf-9f5e-53ab2577ee33" />

- 둘 다 비정상
<img width="1876" height="877" alt="20251217 토큰 검사 - 두 토큰 다 비정상" src="https://github.com/user-attachments/assets/ab30d247-8421-4c3f-900f-b225b121f792" />



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 스웨거 테스트 하실 때 틀린 토큰을 넣고 싶으시면, 화면 속 파라미터가 아니라 f12의 토큰 값을 직접 바꿔주셔야 합니다 (전 지금 알았네요 허허)