### PR TITLE
[Feature] Vercel 프론트엔드 연동을 위한 CORS 설정 추가

### DIFF
--- a/.github/workflows/CI_Test.yml
+++ b/.github/workflows/CI_Test.yml
@@ -18,6 +18,7 @@ jobs:
       CLIENT_ID_GOOGLE: ${{secrets.CLIENT_ID_GOOGLE}}
       REDIRECT_URI_GOOGLE: ${{secrets.REDIRECT_URI_GOOGLE}}
       SECRET_PATTERN: ${{secrets.SECRET_PATTERN}}
+      CORS_ALLOWED_ORIGINS : ${{secrets.CORS_ALLOWED_ORIGINS}}
 
     steps:
       - name: 리포지토리를 가져옵니다

--- a/src/main/java/com/windfall/global/config/WebConfig.java
+++ b/src/main/java/com/windfall/global/config/WebConfig.java
@@ -1,0 +1,38 @@
+package com.windfall.global.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class WebConfig {
+
+  @Value("${custom.cors.allowed-origins}")
+  private String allowedOrigins;
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+
+    List<String> origins = Arrays.stream(allowedOrigins.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .collect(Collectors.toList());
+
+    config.setAllowedOrigins(origins);
+    config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","PATCH","OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+//    config.setExposedHeaders(List.of("Authorization"));
+    config.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
+}

--- a/src/main/java/com/windfall/global/config/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/windfall/global/config/security/CustomAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.windfall.global.security;
+package com.windfall.global.config.security;
 
 import com.windfall.api.user.service.JwtProvider;
 import com.windfall.api.user.service.UserService;

--- a/src/main/java/com/windfall/global/config/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/windfall/global/config/security/CustomAuthenticationFilter.java
@@ -27,6 +27,12 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+    if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
     logger.debug("CustomAuthenticationFilter called");
 
     try {

--- a/src/main/java/com/windfall/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/windfall/global/config/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.windfall.global.security;
+package com.windfall.global.config.security;
 
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/windfall/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/windfall/global/config/security/SecurityConfig.java
@@ -4,6 +4,7 @@ package com.windfall.global.config.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -19,9 +20,11 @@ public class SecurityConfig {
   @Bean
   SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
+        .cors(cors -> {})
         .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
             .requestMatchers("/favicon.ico").permitAll()
             .requestMatchers("/h2-console/**").permitAll()
+            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
             .requestMatchers("/**").permitAll()
             .anyRequest().authenticated())
         .csrf((csrf) -> csrf.disable())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,3 +62,6 @@ custom:
     expireSecondsAccessToken: 3600 # 1시간
     expireSecondsRefreshToken: 604800 # 7일
     secretPattern: ${SECRET_PATTERN}
+
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -52,3 +52,6 @@ custom:
     expireSecondsAccessToken: 3600 # 1시간
     expireSecondsRefreshToken: 604800 # 7일
     secretPattern: ${SECRET_PATTERN}
+
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}


### PR DESCRIPTION
## 📌 관련 이슈
- close #64 

## 📝 변경 사항
### AS-IS
- Spring Security 사용 중이지만 CORS 설정이 명시적으로 존재하지 않아
  프론트엔드(Vercel)에서 API 호출 시 CORS 에러가 발생할 수 있는 상태
- 커스텀 인증 필터에서 preflight(OPTIONS) 요청이 인증 대상이 되어
  Authorization 헤더가 없는 요청이 401로 차단될 가능성이 있었음

### TO-BE
- 환경변수 기반 CORS 설정(WebConfig)을 추가하여 허용 Origin을 유연하게 관리
- SecurityFilterChain에 CORS 설정을 활성화하여 Security 레벨에서 CORS 정상 처리
- CustomAuthenticationFilter에서 OPTIONS 요청을 인증 대상에서 제외하여
  preflight 요청이 정상적으로 통과하도록 개선

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- CORS 설정 방식(WebConfig + SecurityFilterChain)이 현재 구조에 적절한지 확인 부탁드립니다.
- 커스텀 인증 필터에서 OPTIONS 예외 처리 위치가 적절한지도 함께 봐주시면 감사하겠습니다.