### PR TITLE
[Feature] 경매 찜 기능 구현

### DIFF
--- a/src/main/java/com/windfall/api/auction/dto/response/AuctionDetailResponse.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/AuctionDetailResponse.java
@@ -4,7 +4,6 @@ import com.windfall.domain.auction.entity.Auction;
 import com.windfall.api.auction.dto.response.info.SellerInfo;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.enums.AuctionStatus;
-import com.windfall.domain.tag.entity.AuctionTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -70,6 +69,7 @@ public record AuctionDetailResponse(
       double discountRate,
       long stopLoss,
       boolean isLiked,
+      long likeCount,
       long viewerCount,
       List<AuctionHistoryResponse> history,
       List<String> tags
@@ -86,7 +86,7 @@ public record AuctionDetailResponse(
         stopLoss,
         discountRate,
         auction.getStatus(),
-        0L, // auction.getLikeCount(),
+        likeCount,
         isLiked,
         viewerCount,
         auction.getStartedAt(),

--- a/src/main/java/com/windfall/api/auction/service/AuctionService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionService.java
@@ -10,6 +10,7 @@ import com.windfall.api.auction.dto.response.AuctionSearchResponse;
 import com.windfall.api.auction.dto.response.info.PopularInfo;
 import com.windfall.api.auction.dto.response.info.ProcessInfo;
 import com.windfall.api.auction.dto.response.info.ScheduledInfo;
+import com.windfall.api.like.service.AuctionLikeService;
 import com.windfall.api.tag.service.TagService;
 import com.windfall.api.user.service.UserService;
 import com.windfall.domain.auction.entity.Auction;
@@ -17,6 +18,7 @@ import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.auction.repository.AuctionPriceHistoryRepository;
 import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.like.entity.AuctionLike;
 import com.windfall.domain.tag.entity.AuctionTag;
 import com.windfall.domain.tag.entity.Tag;
 import com.windfall.domain.tag.repository.AuctionTagRepository;
@@ -26,6 +28,7 @@ import com.windfall.global.exception.ErrorException;
 import com.windfall.global.response.SliceResponse;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -44,6 +47,7 @@ public class AuctionService {
   private final AuctionViewerService viewerService;
   private final TagService tagService;
   private final AuctionTagRepository auctionTagRepository;
+  private final AuctionLikeService auctionLikeService;
 
   private final RedisTemplate<String, String> redisTemplate;
 
@@ -159,7 +163,7 @@ public class AuctionService {
       exposedStopLoss = auction.getStopLoss();
     }
 
-    // TODO: 타 도메인 의존성 처리 (User, Like)
+    // TODO: 타 도메인 의존성 처리 (User)
 
     long viewerCount = viewerService.getViewerCount(auctionId);
 
@@ -171,12 +175,16 @@ public class AuctionService {
         .map(Tag::getTagName)
         .toList();
 
+    boolean isLiked = isLiked(auctionId, userId);
+    long likeCount = auctionLikeService.getLikeCount(auctionId);
+
     return AuctionDetailResponse.of(
         auction,
         displayPrice,
         discountRate,
         exposedStopLoss,
-        false,
+        isLiked,
+        likeCount,
         viewerCount,
         historyList,
         tags
@@ -196,16 +204,24 @@ public class AuctionService {
       throw new ErrorException(ErrorCode.INVALID_AUCTION_SELLER);
     }
   }
+
   public Auction getAuctionById(Long auctionId) {
     return auctionRepository.findById(auctionId)
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
   }
-
 
   private void validatePrice(Long minPrice, Long maxPrice){
     if(minPrice != null && maxPrice != null && maxPrice < minPrice){
       throw new ErrorException(ErrorCode.INVALID_PRICE);
     }
   }
-}
 
+  private boolean isLiked(Long auctionId, Long userId) {
+    boolean isLiked = false;
+    Optional<AuctionLike> auctionLike = auctionLikeService.getAuctionLike(auctionId, userId);
+    if (auctionLike.isPresent()) {
+      isLiked = true;
+    }
+    return isLiked;
+  }
+}

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
@@ -25,6 +25,5 @@ public class AuctionLikeController implements AuctionLikeSpecification{
   ) {
     AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
     return ApiResponse.ok("찜 토글을 성공했습니다.", response);
-
   }
 }

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auction")
+@RequestMapping("/api/v1/auctions")
 public class AuctionLikeController implements AuctionLikeSpecification{
 
   private final AuctionLikeService auctionLikeService;

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
@@ -6,13 +6,13 @@ import com.windfall.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/vi/auction")
+@RequestMapping("/api/v1/auction")
 public class AuctionLikeController implements AuctionLikeSpecification{
 
   private final AuctionLikeService auctionLikeService;
@@ -21,7 +21,7 @@ public class AuctionLikeController implements AuctionLikeSpecification{
   @PostMapping("/{auctionId}/like")
   public ApiResponse<AuctionLikeResponse> toggleLike(
       @PathVariable Long auctionId,
-      @RequestBody Long userId
+      @RequestParam Long userId // 제거 예정
   ) {
     AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
     return ApiResponse.ok("찜 토글을 성공했습니다.", response);

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
@@ -1,0 +1,30 @@
+package com.windfall.api.like.controller;
+
+import com.windfall.api.like.dto.response.AuctionLikeResponse;
+import com.windfall.api.like.service.AuctionLikeService;
+import com.windfall.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/vi/auction")
+public class AuctionLikeController implements AuctionLikeSpecification{
+
+  private final AuctionLikeService auctionLikeService;
+
+  @Override
+  @PostMapping("/{auctionId}/like")
+  public ApiResponse<AuctionLikeResponse> toggleLike(
+      @PathVariable Long auctionId,
+      @RequestBody Long userId
+  ) {
+    AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
+    return ApiResponse.ok("찜 토글을 성공했습니다.", response);
+
+  }
+}

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
@@ -1,0 +1,25 @@
+package com.windfall.api.like.controller;
+
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_AUCTION;
+
+import com.windfall.api.like.dto.response.AuctionLikeResponse;
+import com.windfall.global.config.swagger.ApiErrorCodes;
+import com.windfall.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Auction Like", description = "경매 찜 API")
+public interface AuctionLikeSpecification {
+
+  @ApiErrorCodes(NOT_FOUND_AUCTION)
+  @Operation(summary = "경매 찜 등록/해제", description = "경매 게시물을 찜 등록/해제할 수 있습니다.")
+  ApiResponse<AuctionLikeResponse> toggleLike(
+      @Parameter(description = "경매 ID", required = true, example = "1")
+      @PathVariable Long auctionId,
+
+      @RequestBody Long userId
+  );
+}

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Auction Like", description = "경매 찜 API")
 public interface AuctionLikeSpecification {
@@ -20,6 +20,7 @@ public interface AuctionLikeSpecification {
       @Parameter(description = "경매 ID", required = true, example = "1")
       @PathVariable Long auctionId,
 
-      @RequestBody Long userId
+      @Parameter(description = "로그인 구현 후, 제거 예정", required = true, example = "1")
+      @RequestParam Long userId
   );
 }

--- a/src/main/java/com/windfall/api/like/dto/response/AuctionLikeResponse.java
+++ b/src/main/java/com/windfall/api/like/dto/response/AuctionLikeResponse.java
@@ -5,13 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "찜 등록/해제 응답 DTO")
 public record AuctionLikeResponse(
 
-    @Schema(description = "찜 활성화 여부")
-    boolean like,
+    @Schema(description = "사용자 찜 여부")
+    boolean isLiked,
 
     @Schema(description = "찜 개수")
     long likeCount
 ) {
-    public static AuctionLikeResponse of (boolean like, long likeCount) {
-        return new AuctionLikeResponse(like, likeCount);
+    public static AuctionLikeResponse of (boolean isLiked, long likeCount) {
+        return new AuctionLikeResponse(isLiked, likeCount);
     }
 }

--- a/src/main/java/com/windfall/api/like/dto/response/AuctionLikeResponse.java
+++ b/src/main/java/com/windfall/api/like/dto/response/AuctionLikeResponse.java
@@ -1,0 +1,17 @@
+package com.windfall.api.like.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "찜 등록/해제 응답 DTO")
+public record AuctionLikeResponse(
+
+    @Schema(description = "찜 활성화 여부")
+    boolean like,
+
+    @Schema(description = "찜 개수")
+    long likeCount
+) {
+    public static AuctionLikeResponse of (boolean like, long likeCount) {
+        return new AuctionLikeResponse(like, likeCount);
+    }
+}

--- a/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
+++ b/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
@@ -23,7 +23,7 @@ public class AuctionLikeService {
   public AuctionLikeResponse toggleLike(Long auctionId, Long userId) {
     Auction auction = getAuction(auctionId);
 
-    Optional<AuctionLike> existingLike = getAuctionLike(userId, auction);
+    Optional<AuctionLike> existingLike = getAuctionLike(auctionId, userId);
 
     boolean isLiked;
 
@@ -35,7 +35,7 @@ public class AuctionLikeService {
       isLiked = true;
     }
 
-    long likeCount = auctionLikeRepository.countByAuction(auction);
+    long likeCount = getLikeCount(auctionId);
 
     return AuctionLikeResponse.of(isLiked, likeCount);
   }
@@ -45,7 +45,13 @@ public class AuctionLikeService {
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
   }
 
-  private Optional<AuctionLike> getAuctionLike(Long userId, Auction auction) {
-    return auctionLikeRepository.findByAuctionAndUserId(auction, userId);
+  @Transactional(readOnly = true)
+  public Optional<AuctionLike> getAuctionLike(Long auctionId, Long userId) {
+    return auctionLikeRepository.findByAuctionIdAndUserId(auctionId, userId);
+  }
+
+  @Transactional(readOnly = true)
+  public long getLikeCount(Long auctionId) {
+    return auctionLikeRepository.countByAuctionId(auctionId);
   }
 }

--- a/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
+++ b/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
@@ -25,19 +25,19 @@ public class AuctionLikeService {
 
     Optional<AuctionLike> existingLike = getAuctionLike(userId, auction);
 
-    boolean like;
+    boolean isLiked;
 
     if (existingLike.isPresent()) {
       auctionLikeRepository.delete(existingLike.get());
-      like = false;
+      isLiked = false;
     } else {
       auctionLikeRepository.save(AuctionLike.create(auction, userId));
-      like = true;
+      isLiked = true;
     }
 
     long likeCount = auctionLikeRepository.countByAuction(auction);
 
-    return AuctionLikeResponse.of(like, likeCount);
+    return AuctionLikeResponse.of(isLiked, likeCount);
   }
 
   private Auction getAuction(Long auctionId) {

--- a/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
+++ b/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
@@ -1,0 +1,51 @@
+package com.windfall.api.like.service;
+
+import com.windfall.api.like.dto.response.AuctionLikeResponse;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.like.entity.AuctionLike;
+import com.windfall.domain.like.repository.AuctionLikeRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionLikeService {
+
+  private final AuctionLikeRepository auctionLikeRepository;
+  private final AuctionRepository auctionRepository;
+
+  @Transactional
+  public AuctionLikeResponse toggleLike(Long auctionId, Long userId) {
+    Auction auction = getAuction(auctionId);
+
+    Optional<AuctionLike> existingLike = getAuctionLike(userId, auction);
+
+    boolean like;
+
+    if (existingLike.isPresent()) {
+      auctionLikeRepository.delete(existingLike.get());
+      like = false;
+    } else {
+      auctionLikeRepository.save(AuctionLike.create(auction, userId));
+      like = true;
+    }
+
+    long likeCount = auctionLikeRepository.countByAuction(auction);
+
+    return AuctionLikeResponse.of(like, likeCount);
+  }
+
+  private Optional<AuctionLike> getAuctionLike(Long userId, Auction auction) {
+    return auctionLikeRepository.findByAuctionAndUserId(auction, userId);
+  }
+
+  private Auction getAuction(Long auctionId) {
+    return auctionRepository.findById(auctionId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
+  }
+}

--- a/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
+++ b/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
@@ -40,12 +40,12 @@ public class AuctionLikeService {
     return AuctionLikeResponse.of(like, likeCount);
   }
 
-  private Optional<AuctionLike> getAuctionLike(Long userId, Auction auction) {
-    return auctionLikeRepository.findByAuctionAndUserId(auction, userId);
-  }
-
   private Auction getAuction(Long auctionId) {
     return auctionRepository.findById(auctionId)
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
+  }
+
+  private Optional<AuctionLike> getAuctionLike(Long userId, Auction auction) {
+    return auctionLikeRepository.findByAuctionAndUserId(auction, userId);
   }
 }

--- a/src/main/java/com/windfall/domain/like/entity/AuctionLike.java
+++ b/src/main/java/com/windfall/domain/like/entity/AuctionLike.java
@@ -4,8 +4,11 @@ import com.windfall.domain.auction.entity.Auction;
 import com.windfall.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,14 +16,27 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "auction_like",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_auction_like_auction_user",
+            columnNames = {"auction_id", "user_id"}
+        )
+    }
+)
 public class AuctionLike extends BaseEntity {
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "auction_id", nullable = false)
   private Auction auction;
 
   @Column(nullable = false)
   private Long userId;
+
+  public static AuctionLike create(Auction auction, Long userId) {
+    return new AuctionLike(auction, userId);
+  }
 }

--- a/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
+++ b/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuctionLikeRepository extends JpaRepository<AuctionLike, Long> {
 
-  Optional<AuctionLike> findByAuctionAndUserId(Auction auction, Long userId);
+  Optional<AuctionLike> findByAuctionIdAndUserId(Long auctionId, Long userId);
 
-  long countByAuction(Auction auction);
+  long countByAuctionId(Long auctionId);
 }

--- a/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
+++ b/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
@@ -1,8 +1,13 @@
 package com.windfall.domain.like.repository;
 
+import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.like.entity.AuctionLike;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuctionLikeRepository extends JpaRepository<AuctionLike, Long> {
 
+  Optional<AuctionLike> findByAuctionAndUserId(Auction auction, Long userId);
+
+  long countByAuction(Auction auction);
 }

--- a/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
+++ b/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
@@ -56,7 +56,7 @@ class AuctionLikeServiceTest {
     // then
     verify(auctionLikeRepository, times(1)).save(any(AuctionLike.class));
     verify(auctionLikeRepository, never()).delete(any());
-    assertThat(response.like()).isTrue();
+    assertThat(response.isLiked()).isTrue();
     assertThat(response.likeCount()).isEqualTo(1L);
   }
 
@@ -76,7 +76,7 @@ class AuctionLikeServiceTest {
     // then
     verify(auctionLikeRepository, times(1)).delete(existingLike);
     verify(auctionLikeRepository, never()).save(any());
-    assertThat(response.like()).isFalse();
+    assertThat(response.isLiked()).isFalse();
     assertThat(response.likeCount()).isEqualTo(0L);
   }
 

--- a/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
+++ b/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
@@ -1,0 +1,100 @@
+package com.windfall.api.like;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.windfall.api.like.dto.response.AuctionLikeResponse;
+import com.windfall.api.like.service.AuctionLikeService;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.like.entity.AuctionLike;
+import com.windfall.domain.like.repository.AuctionLikeRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AuctionLikeServiceTest {
+
+  @InjectMocks
+  private AuctionLikeService auctionLikeService;
+
+  @Mock
+  private AuctionLikeRepository auctionLikeRepository;
+
+  @Mock
+  private AuctionRepository auctionRepository;
+
+  @Mock
+  private Auction auction;
+
+  Long userId = 1L;
+  Long auctionId = 1L;
+
+  @Test
+  @DisplayName("[경매찜1] 찜이 아닐 때, 경매 찜하는 경우")
+  void success1() {
+    // given
+    when(auctionRepository.findById(auctionId)).thenReturn(Optional.of(auction));
+    when(auctionLikeRepository.findByAuctionAndUserId(auction, userId)).thenReturn(
+        Optional.empty());
+    when(auctionLikeRepository.countByAuction(auction)).thenReturn(1L);
+
+    // when
+    AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
+
+    // then
+    verify(auctionLikeRepository, times(1)).save(any(AuctionLike.class));
+    verify(auctionLikeRepository, never()).delete(any());
+    assertThat(response.like()).isTrue();
+    assertThat(response.likeCount()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("[경매찜2] 이미 찜일 때, 경매 찜하는 경우")
+  void success2() {
+    // given
+    AuctionLike existingLike = AuctionLike.create(auction, userId);
+    when(auctionRepository.findById(auctionId)).thenReturn(Optional.of(auction));
+    when(auctionLikeRepository.findByAuctionAndUserId(auction, userId)).thenReturn(
+        Optional.of(existingLike));
+    when(auctionLikeRepository.countByAuction(auction)).thenReturn(0L);
+
+    // when
+    AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
+
+    // then
+    verify(auctionLikeRepository, times(1)).delete(existingLike);
+    verify(auctionLikeRepository, never()).save(any());
+    assertThat(response.like()).isFalse();
+    assertThat(response.likeCount()).isEqualTo(0L);
+  }
+
+  @Test
+  @DisplayName("[경매찜 예외1] 경매 게시물이 존재하지 않는 경우")
+  void exception1() {
+    // given
+    when(auctionRepository.findById(auctionId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> auctionLikeService.toggleLike(auctionId, userId))
+        .isInstanceOf(ErrorException.class)
+        .satisfies(e -> {
+          ErrorException ex = (ErrorException) e;
+          assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND_AUCTION);
+        });
+
+    verify(auctionLikeRepository, never()).save(any());
+    verify(auctionLikeRepository, never()).delete(any());
+  }
+}

--- a/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
+++ b/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
@@ -46,9 +46,9 @@ class AuctionLikeServiceTest {
   void success1() {
     // given
     when(auctionRepository.findById(auctionId)).thenReturn(Optional.of(auction));
-    when(auctionLikeRepository.findByAuctionAndUserId(auction, userId)).thenReturn(
+    when(auctionLikeRepository.findByAuctionIdAndUserId(auctionId, userId)).thenReturn(
         Optional.empty());
-    when(auctionLikeRepository.countByAuction(auction)).thenReturn(1L);
+    when(auctionLikeRepository.countByAuctionId(auctionId)).thenReturn(1L);
 
     // when
     AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
@@ -66,9 +66,9 @@ class AuctionLikeServiceTest {
     // given
     AuctionLike existingLike = AuctionLike.create(auction, userId);
     when(auctionRepository.findById(auctionId)).thenReturn(Optional.of(auction));
-    when(auctionLikeRepository.findByAuctionAndUserId(auction, userId)).thenReturn(
+    when(auctionLikeRepository.findByAuctionIdAndUserId(auctionId, userId)).thenReturn(
         Optional.of(existingLike));
-    when(auctionLikeRepository.countByAuction(auction)).thenReturn(0L);
+    when(auctionLikeRepository.countByAuctionId(auctionId)).thenReturn(0L);
 
     // when
     AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);


### PR DESCRIPTION
## 📌 관련 이슈
- close #70 

## 📝 변경 사항
### AS-IS
- 경매 찜 기능, 테스트 코드 부재
- 경매 상세 조회 시 찜 여부, 찜 개수 조회 로직 부재

### TO-BE
- 경매 찜 API 구현(컨트롤러, 서비스 로직): 토글 형식
- 테스트 코드 추가 (3개)
- 경매 상세 조회 시 찜 여부, 찜 개수 조회 로직 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="450" height="215" alt="image" src="https://github.com/user-attachments/assets/8b62aaac-0627-43b4-91fe-dbdcd5d2c7c1" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 경매 상세 조회는 단순한 조회 로직만 추가하면 하면 돼서 추가했습니다.
- 경매 찜 개발 끝입니다.