### PR TITLE
[Feature] 경매 가격 하락 내역 조회 (무한 스크롤) 구현

### DIFF
--- a/src/main/java/com/windfall/api/auction/controller/AuctionController.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionController.java
@@ -1,5 +1,7 @@
 package com.windfall.api.auction.controller;
 
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
 import com.windfall.api.auction.dto.request.AuctionCreateRequest;
 import com.windfall.api.auction.dto.response.AuctionCancelResponse;
 import com.windfall.api.auction.dto.response.AuctionCreateResponse;
@@ -18,8 +20,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -41,9 +45,9 @@ public class AuctionController implements AuctionSpecification {
   @PostMapping
   public ApiResponse<AuctionCreateResponse> createAuction(
       @Valid @RequestBody AuctionCreateRequest request
-  ){
+  ) {
     AuctionCreateResponse response = auctionService.createAuction(request);
-    return ApiResponse.created("경매가 생성되었습니다.",response);
+    return ApiResponse.created("경매가 생성되었습니다.", response);
   }
 
   @Override
@@ -54,24 +58,25 @@ public class AuctionController implements AuctionSpecification {
       @RequestParam(required = false) AuctionStatus status,
       @RequestParam(defaultValue = "0") Long minPrice,
       @RequestParam(required = false) Long maxPrice,
-      @RequestParam @Min(value = 1,message = "page는 1부터 시작합니다.") int page,
+      @RequestParam @Min(value = 1, message = "page는 1부터 시작합니다.") int page,
       @RequestParam(defaultValue = "15") int size,
       @RequestParam(defaultValue = "createDate") String sortBy,
       @RequestParam(defaultValue = "ASC") Direction sortDirection
       // TODO 태그 관련 + 필터링(최신순, 인기순, 오래된 순 등등)
-  ){
+  ) {
 
-    PageRequest pageable = PageRequest.of(page,size,Sort.by(sortDirection,sortBy));
-    SliceResponse<AuctionSearchResponse> response = auctionService.searchAuction(pageable,query, category, status, minPrice, maxPrice);
+    PageRequest pageable = PageRequest.of(page, size, Sort.by(sortDirection, sortBy));
+    SliceResponse<AuctionSearchResponse> response = auctionService.searchAuction(pageable, query,
+        category, status, minPrice, maxPrice);
     return ApiResponse.ok("경매 검색에 성공했습니다.", response);
   }
 
   @Override
   @GetMapping
   public ApiResponse<AuctionListReadResponse> readAuctionList(
-  ){
+  ) {
     AuctionListReadResponse response = auctionService.readAuctionList();
-    return ApiResponse.ok("경매 목록 조회에 성공했습니다.",response);
+    return ApiResponse.ok("경매 목록 조회에 성공했습니다.", response);
   }
 
   @Override
@@ -88,12 +93,14 @@ public class AuctionController implements AuctionSpecification {
 
   @Override
   @GetMapping("/{auctionId}/history")
-  public ApiResponse<AuctionHistoryResponse> getAuctionHistory(
-      @PathVariable Long auctionId) {
+  public ApiResponse<SliceResponse<AuctionHistoryResponse>> getAuctionHistory(
+      @PathVariable Long auctionId,
+      @PageableDefault(size = 10, sort = "createDate", direction = DESC) Pageable pageable) {
 
-    //TODO: 경매 가격 변동 내역 조회 로직 구현
+    SliceResponse<AuctionHistoryResponse> response = auctionService.getAuctionHistory(
+        auctionId, pageable);
 
-    return ApiResponse.ok(null);
+    return ApiResponse.ok("경매 가격 변동 내역이 조회되었습니다.", response);
   }
 
   @Override
@@ -114,7 +121,7 @@ public class AuctionController implements AuctionSpecification {
       @PathVariable Long auctionId,
 
       @RequestParam Long userId
-  ){
+  ) {
     AuctionCancelResponse response = auctionService.cancelAuction(auctionId, userId);
     return ApiResponse.ok("경매가 취소되었습니다.", response);
   }
@@ -126,7 +133,7 @@ public class AuctionController implements AuctionSpecification {
 
       // TODO 임시 유저 id -> 로그인 개발 시 제거해야 함
       @RequestParam Long userId
-  ){
+  ) {
     auctionService.deleteAuction(auctionId, userId);
     return ApiResponse.noContent();
   }

--- a/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
@@ -30,7 +30,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -89,10 +92,12 @@ public interface AuctionSpecification {
   );
 
   @ApiErrorCodes({NOT_FOUND_AUCTION})
-  @Operation(summary = "경매 가격 변동 내역 조회", description = "특정 경매의 가격 변동 내역을 조회합니다.")
-  ApiResponse<AuctionHistoryResponse> getAuctionHistory(
+  @Operation(summary = "경매 가격 변동 내역 조회", description = "특정 경매의 가격 변동 내역을 조회합니다.( 10개씩 최신순 무한 스크롤 )")
+  ApiResponse<SliceResponse<AuctionHistoryResponse>> getAuctionHistory(
       @Parameter(description = "경매 ID", required = true, example = "1")
-      @PathVariable Long auctionId
+      @PathVariable Long auctionId,
+
+      @ParameterObject Pageable pageable
   );
 
   @ApiErrorCodes({NOT_FOUND_AUCTION, NOT_FOUND_USER, AUCTION_NOT_PROCESS ,INVALID_AUCTION_SELLER})

--- a/src/main/java/com/windfall/api/auction/dto/response/AuctionDetailResponse.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/AuctionDetailResponse.java
@@ -1,10 +1,9 @@
 package com.windfall.api.auction.dto.response;
 
-import com.windfall.domain.auction.entity.Auction;
 import com.windfall.api.auction.dto.response.info.SellerInfo;
+import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.enums.AuctionStatus;
-import com.windfall.domain.tag.entity.AuctionTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -61,7 +60,10 @@ public record AuctionDetailResponse(
     List<AuctionHistoryResponse> recentPriceHistory,
 
     @Schema(description = "태그 목록")
-    List<String> tags
+    List<String> tags,
+
+    @Schema(description = "서버 시간")
+    LocalDateTime serverTime
 
 ) {
   public static AuctionDetailResponse of(
@@ -91,7 +93,8 @@ public record AuctionDetailResponse(
         viewerCount,
         auction.getStartedAt(),
         history,
-        tags
+        tags,
+        LocalDateTime.now()
     );
   }
 }

--- a/src/main/java/com/windfall/api/auction/dto/response/info/SellerInfo.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/info/SellerInfo.java
@@ -13,22 +13,14 @@ public record SellerInfo(
     String nickname,
 
     @Schema(description = "판매자 프로필 이미지 URL")
-    String profileImageUrl,
-
-    @Schema(description = "판매자 평점")
-    double rating,
-
-    @Schema(description = "판매자 리뷰 수")
-    Long reviewCount
+    String profileImageUrl
 
 ) {
   public static SellerInfo from(User user) {
     return new SellerInfo(
         user.getId(),
         "닉네임", // user.getNickname(),
-        "https://example.png", // user.getProfileImageUrl(),
-        0.0, // user.getRating(),
-        0L // user.getReviewCount()
+        "https://example.png" // user.getProfileImageUrl(),
     );
   }
 }

--- a/src/main/java/com/windfall/api/auction/service/AuctionService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionService.java
@@ -183,6 +183,18 @@ public class AuctionService {
     );
   }
 
+  public SliceResponse<AuctionHistoryResponse> getAuctionHistory(Long auctionId,
+      Pageable pageable) {
+
+    getAuctionById(auctionId);
+
+    Slice<AuctionHistoryResponse> historySlice = historyRepository.findByAuction_IdOrderByCreateDateDesc(
+            auctionId, pageable)
+        .map(AuctionHistoryResponse::from);
+
+    return SliceResponse.from(historySlice);
+  }
+
   private List<AuctionHistoryResponse> getRecentHistories(Long auctionId) {
 
     return historyRepository.findTop5ByAuction_IdOrderByCreateDateDesc(auctionId)
@@ -196,11 +208,11 @@ public class AuctionService {
       throw new ErrorException(ErrorCode.INVALID_AUCTION_SELLER);
     }
   }
+
   public Auction getAuctionById(Long auctionId) {
     return auctionRepository.findById(auctionId)
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
   }
-
 
   private void validatePrice(Long minPrice, Long maxPrice){
     if(minPrice != null && maxPrice != null && maxPrice < minPrice){

--- a/src/main/java/com/windfall/domain/auction/repository/AuctionPriceHistoryRepository.java
+++ b/src/main/java/com/windfall/domain/auction/repository/AuctionPriceHistoryRepository.java
@@ -2,10 +2,14 @@ package com.windfall.domain.auction.repository;
 
 import com.windfall.domain.auction.entity.AuctionPriceHistory;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuctionPriceHistoryRepository extends JpaRepository<AuctionPriceHistory, Long> {
 
   List<AuctionPriceHistory> findTop5ByAuction_IdOrderByCreateDateDesc(Long auctionId);
+
+  Slice<AuctionPriceHistory> findByAuction_IdOrderByCreateDateDesc(Long auctionId, Pageable pageable);
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #73 

## 📝 변경 사항
### AS-IS
- 모든 가격 하락 내역 조회 부재
- slice 도입 부재
- 프론트 요청 처리 부재

### TO-BE
- `@PageableDefault(size = 10)` 설정을 통해 기본 페이징 값 적용
- `AuctionPriceHistoryRepository`: `findByAuction_IdOrderByCreateDateDesc` 메서드 추가 (Slice 반환)
- `AuctionService`: `getAuctionHistory` 구현
- 프론트 요청
   - `AuctionDetailResponse`: 서버 시간(`serverTime`) 필드 추가 및 응답 시점(`LocalDateTime.now()`) 주입 
   - `SellerInfo `판매자 리뷰 관련 내역 제거

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 최신순 정렬
- hashNext로 다음 페이지 여부 확인
- page / size 확인
<img width="403" height="383" alt="image" src="https://github.com/user-attachments/assets/ee67d700-6ce5-421f-a2fe-e1213fcf09a6" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
되기만 한 코드로 경매 상세는 끝입니다.