### PR TITLE
[Feature] 판매내역 조회 API 구현

### DIFF
--- a/src/main/java/com/windfall/api/chat/dto/response/info/ChatInfo.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/info/ChatInfo.java
@@ -1,0 +1,7 @@
+package com.windfall.api.chat.dto.response.info;
+
+public record ChatInfo(
+    Long roomId,
+    int unreadCount
+) {
+}

--- a/src/main/java/com/windfall/api/user/controller/UserInfoSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/UserInfoSpecification.java
@@ -1,9 +1,13 @@
 package com.windfall.api.user.controller;
 
 import com.windfall.api.user.dto.response.UserInfoResponse;
+import com.windfall.api.user.dto.response.saleshistory.BaseSalesHistoryResponse;
 import com.windfall.global.response.ApiResponse;
+import com.windfall.global.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -12,5 +16,14 @@ public interface UserInfoSpecification {
 
   @Operation(summary = "사용자 정보", description = "특정 사용자의 정보를 반환합니다.")
   ApiResponse<UserInfoResponse> getUserInfo(@PathVariable Long userid, @RequestParam Long loginId);
+
+  @Operation(summary = "사용자 판매 내역", description = "특정 사용자의 판매 내역을 반환합니다.")
+  ApiResponse<SliceResponse<BaseSalesHistoryResponse>> getUserSalesHistory(
+      @PathVariable Long userid,
+      @RequestParam Long loginId,
+      @RequestParam(required = false) String filter,
+      @PageableDefault(page = 0, size = 10) Pageable pageable
+
+  );
 
 }

--- a/src/main/java/com/windfall/api/user/controller/UserinfoController.java
+++ b/src/main/java/com/windfall/api/user/controller/UserinfoController.java
@@ -1,11 +1,13 @@
 package com.windfall.api.user.controller;
 
-import com.windfall.api.user.dto.response.LoginUserResponse;
 import com.windfall.api.user.dto.response.UserInfoResponse;
+import com.windfall.api.user.dto.response.saleshistory.BaseSalesHistoryResponse;
 import com.windfall.api.user.service.UserInfoService;
 import com.windfall.global.response.ApiResponse;
+import com.windfall.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +29,18 @@ public class UserinfoController implements UserInfoSpecification{
     UserInfoResponse response = userInfoService.getUserInfo(userid, loginId);
 
     return ApiResponse.ok("사용자 정보 조회에 성공했습니다.", response);
+  }
+
+  @Override
+  @GetMapping("/{userid}/sales")
+  public ApiResponse<SliceResponse<BaseSalesHistoryResponse>> getUserSalesHistory(
+      @PathVariable Long userid,
+      @RequestParam(defaultValue = "1") Long loginId,
+      @RequestParam(required = false) String filter,
+      @PageableDefault(page = 0, size = 10) Pageable pageable) {
+
+    SliceResponse<BaseSalesHistoryResponse> response = userInfoService.getUserSalesHistory(userid, loginId, filter, pageable);
+
+    return ApiResponse.ok("사용자 판매내역 조회에 성공했습니다.", response);
   }
 }

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/BaseSalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/BaseSalesHistoryResponse.java
@@ -1,15 +1,35 @@
 package com.windfall.api.user.dto.response.saleshistory;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import lombok.Getter;
 
 @Getter
+@Schema(
+    subTypes = { // 자식 클래스
+        SalesHistoryResponse.class,
+        ProcessingSalesHistoryResponse.class,
+        CompletedSalesHistoryResponse.class,
+        OwnerCompletedSalesHistoryResponse.class
+    }
+)
 public abstract class BaseSalesHistoryResponse {
+  @Schema(description = "경매 상태")
   private final String status;
+
+  @Schema(description = "경매 id")
   private final Long auctionId;
+
+  @Schema(description = "경매 제목")
   private final String title;
+
+  @Schema(description = "경매 이미지 url")
   private final String auctionImageUrl;
+
+  @Schema(description = "경매 시작가")
   private final int startPrice;
+
+  @Schema(description = "경매 시작일")
   private final LocalDate startedAt;
 
   public BaseSalesHistoryResponse(String status, Long auctionId, String title, String auctionImageUrl,

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/BaseSalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/BaseSalesHistoryResponse.java
@@ -1,0 +1,24 @@
+package com.windfall.api.user.dto.response.saleshistory;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public abstract class BaseSalesHistoryResponse {
+  private final String status;
+  private final Long auctionId;
+  private final String title;
+  private final String auctionImageUrl;
+  private final int startPrice;
+  private final LocalDate startedAt;
+
+  public BaseSalesHistoryResponse(String status, Long auctionId, String title, String auctionImageUrl,
+      int startPrice, LocalDate startedAt) {
+    this.status = status;
+    this.auctionId = auctionId;
+    this.title = title;
+    this.auctionImageUrl = auctionImageUrl;
+    this.startPrice = startPrice;
+    this.startedAt = startedAt;
+  }
+}

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/CompletedSalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/CompletedSalesHistoryResponse.java
@@ -1,6 +1,7 @@
 package com.windfall.api.user.dto.response.saleshistory;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Tuple;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -21,8 +22,13 @@ import lombok.Getter;
 }) //json 출력 순서 맞추기
 public class CompletedSalesHistoryResponse extends BaseSalesHistoryResponse {
 
+  @Schema(description = "하락 퍼센트")
   private final int discountPercent;
+
+  @Schema(description = "종료 가격")
   private final int endPrice;
+
+  @Schema(description = "거래 상태")
   private final String tradeStatus;
 
   @Builder

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/CompletedSalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/CompletedSalesHistoryResponse.java
@@ -1,0 +1,53 @@
+package com.windfall.api.user.dto.response.saleshistory;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "endPrice",
+    "discountPercent",
+    "startedAt",
+    "tradeStatus",
+}) //json 출력 순서 맞추기
+public class CompletedSalesHistoryResponse extends BaseSalesHistoryResponse {
+
+  private final int discountPercent;
+  private final int endPrice;
+  private final String tradeStatus;
+
+  @Builder
+  public CompletedSalesHistoryResponse(String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt, int discountPercent,
+      int endPrice, String tradeStatus) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    this.discountPercent = discountPercent;
+    this.endPrice = endPrice;
+    this.tradeStatus = tradeStatus;
+  }
+
+  public static CompletedSalesHistoryResponse from(Tuple tuple){
+    return CompletedSalesHistoryResponse
+        .builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .startedAt(tuple.get("startedAt", java.sql.Date.class).toLocalDate())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .endPrice(tuple.get("endPrice", Long.class).intValue())
+        .tradeStatus(tuple.get("tradeStatus", String.class))
+        .build();
+  }
+
+}

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/OwnerCompletedSalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/OwnerCompletedSalesHistoryResponse.java
@@ -2,6 +2,7 @@ package com.windfall.api.user.dto.response.saleshistory;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.windfall.api.chat.dto.response.info.ChatInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Tuple;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -23,9 +24,16 @@ import lombok.Getter;
 }) //json 출력 순서 맞추기
 public class OwnerCompletedSalesHistoryResponse extends BaseSalesHistoryResponse {
 
+  @Schema(description = "하락 퍼센트")
   private final int discountPercent;
+
+  @Schema(description = "종료 가격")
   private final int endPrice;
+
+  @Schema(description = "거래 상태")
   private final String tradeStatus;
+
+  @Schema(description = "채팅 정보")
   private final ChatInfo chatInfo;
 
   @Builder

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/OwnerCompletedSalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/OwnerCompletedSalesHistoryResponse.java
@@ -1,0 +1,59 @@
+package com.windfall.api.user.dto.response.saleshistory;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.windfall.api.chat.dto.response.info.ChatInfo;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "endPrice",
+    "discountPercent",
+    "startedAt",
+    "tradeStatus",
+    "chatInfo"
+}) //json 출력 순서 맞추기
+public class OwnerCompletedSalesHistoryResponse extends BaseSalesHistoryResponse {
+
+  private final int discountPercent;
+  private final int endPrice;
+  private final String tradeStatus;
+  private final ChatInfo chatInfo;
+
+  @Builder
+  public OwnerCompletedSalesHistoryResponse(String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt, int discountPercent,
+      int endPrice, String tradeStatus, Long roomId, int unreadCount) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    this.discountPercent = discountPercent;
+    this.endPrice = endPrice;
+    this.tradeStatus = tradeStatus;
+    this.chatInfo = new ChatInfo(roomId, unreadCount);
+  }
+
+  public static OwnerCompletedSalesHistoryResponse from(Tuple tuple){
+    return OwnerCompletedSalesHistoryResponse
+        .builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .startedAt(tuple.get("startedAt", java.sql.Date.class).toLocalDate())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .endPrice(tuple.get("endPrice", Long.class).intValue())
+        .tradeStatus(tuple.get("tradeStatus", String.class))
+        .roomId(tuple.get("roomId", Long.class))
+        .unreadCount(tuple.get("unreadCount", BigDecimal.class).intValue())
+        .build();
+  }
+
+}

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/ProcessingSalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/ProcessingSalesHistoryResponse.java
@@ -1,0 +1,51 @@
+package com.windfall.api.user.dto.response.saleshistory;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "currentPrice",
+    "discountPercent",
+    "startedAt",
+    "tradeStatus",
+}) //json 출력 순서 맞추기
+public class ProcessingSalesHistoryResponse extends BaseSalesHistoryResponse {
+
+  int currentPrice;
+  int discountPercent;
+
+  @Builder
+  public ProcessingSalesHistoryResponse(String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt, int currentPrice,
+      int discountPercent) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    this.currentPrice = currentPrice;
+    this.discountPercent = discountPercent;
+  }
+
+  public static ProcessingSalesHistoryResponse from(Tuple tuple){
+    return ProcessingSalesHistoryResponse
+        .builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .startedAt(tuple.get("startedAt", java.sql.Date.class).toLocalDate())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .currentPrice(tuple.get("currentPrice", Long.class).intValue())
+        .build();
+
+  }
+
+}

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/ProcessingSalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/ProcessingSalesHistoryResponse.java
@@ -1,6 +1,7 @@
 package com.windfall.api.user.dto.response.saleshistory;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Tuple;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -21,7 +22,10 @@ import lombok.Getter;
 }) //json 출력 순서 맞추기
 public class ProcessingSalesHistoryResponse extends BaseSalesHistoryResponse {
 
+  @Schema(description = "현재가")
   int currentPrice;
+
+  @Schema(description = "하락 퍼센트")
   int discountPercent;
 
   @Builder

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/SalesHistoryRaw.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/SalesHistoryRaw.java
@@ -1,0 +1,10 @@
+package com.windfall.api.user.dto.response.saleshistory;
+
+import com.windfall.domain.auction.enums.AuctionStatus;
+
+public record SalesHistoryRaw(
+    Long id,
+    AuctionStatus status
+) {
+
+}

--- a/src/main/java/com/windfall/api/user/dto/response/saleshistory/SalesHistoryResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/saleshistory/SalesHistoryResponse.java
@@ -1,0 +1,36 @@
+package com.windfall.api.user.dto.response.saleshistory;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.persistence.Tuple;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "startedAt",
+}) //json 출력 순서 맞추기
+public class SalesHistoryResponse extends BaseSalesHistoryResponse{
+
+  @Builder
+  public SalesHistoryResponse(String status, Long auctionId, String title, String auctionImageUrl,
+      int startPrice, LocalDate startedAt) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+  }
+
+  public static SalesHistoryResponse from(Tuple tuple){
+    return SalesHistoryResponse.builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .startedAt(tuple.get("startedAt", java.sql.Date.class).toLocalDate())
+        .build();
+  }
+}

--- a/src/main/java/com/windfall/api/user/service/UserInfoService.java
+++ b/src/main/java/com/windfall/api/user/service/UserInfoService.java
@@ -1,8 +1,26 @@
 package com.windfall.api.user.service;
 
 import com.windfall.api.user.dto.response.UserInfoResponse;
+import com.windfall.api.user.dto.response.saleshistory.CompletedSalesHistoryResponse;
+import com.windfall.api.user.dto.response.saleshistory.OwnerCompletedSalesHistoryResponse;
+import com.windfall.api.user.dto.response.saleshistory.ProcessingSalesHistoryResponse;
+import com.windfall.api.user.dto.response.saleshistory.SalesHistoryRaw;
+import com.windfall.api.user.dto.response.saleshistory.BaseSalesHistoryResponse;
+import com.windfall.api.user.dto.response.saleshistory.SalesHistoryResponse;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import com.windfall.domain.auction.enums.AuctionStatusGroup;
+import com.windfall.domain.user.repository.SalesHistoryQueryRepository;
 import com.windfall.domain.user.repository.UserRepository;
+import com.windfall.global.response.SliceResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +30,7 @@ public class UserInfoService {
 
   private final UserService userService;
   private final UserRepository userRepository;
+  private final SalesHistoryQueryRepository salesHistoryQueryRepository;
 
   @Transactional
   public UserInfoResponse getUserInfo(Long userid, Long loginId){ //userDetails 추가될 경우 리팩토링 예정
@@ -19,4 +38,80 @@ public class UserInfoService {
 
     return userRepository.findByUserInfo(userid, loginId);
   }
+
+  @Transactional
+  public SliceResponse<BaseSalesHistoryResponse> getUserSalesHistory(Long userid, Long loginId,String filter, Pageable pageable){
+    userService.getUserById(userid); //조회할 유저가 있는지 먼저 검색
+
+    //1. raw data 추출
+    Slice<SalesHistoryRaw> rawData = salesHistoryQueryRepository.getRawSalesHistory(userid, filter, pageable);
+
+    //2. 순서 저장
+    List<Long> dataSequence = rawData.stream().map(SalesHistoryRaw::id).toList();
+
+    //3. 분기 처리 (그룹화)
+    Map<AuctionStatusGroup, List<Long>> groups = groupingStatus(rawData.getContent(), userid, loginId);
+
+    //4. 분기 별 다른 쿼리 실행
+    Map<Long, BaseSalesHistoryResponse> resultData = fetchDetailedData(groups, userid);
+
+    //5. 정렬 조립 작업
+    List<BaseSalesHistoryResponse> resultContent = dataSequence.stream().map(resultData::get).toList();
+
+    //6. 다시 slice로 반환
+    Slice<BaseSalesHistoryResponse> resultSlice = new SliceImpl<>(
+        resultContent,
+        rawData.getPageable(),
+        rawData.hasNext()
+    );
+
+    return SliceResponse.from(resultSlice);
+  }
+
+  private Map<AuctionStatusGroup, List<Long>> groupingStatus(List<SalesHistoryRaw> rawData, Long userid, Long loginId){
+    Map<AuctionStatusGroup, List<Long>> groups = new HashMap<>(); //분기 처리용 map
+    rawData.forEach(raw -> {
+      AuctionStatusGroup key = setGroup(raw.status(), userid, loginId);
+      groups.computeIfAbsent(key, k -> new ArrayList<>()).add(raw.id());
+    });
+
+    return groups;
+  }
+
+  private AuctionStatusGroup setGroup(AuctionStatus status, Long userid, Long loginId){ //그룹 설정
+    if(status == AuctionStatus.SCHEDULED || status == AuctionStatus.CANCELED) { //group1 : 예정, 취소
+      return AuctionStatusGroup.READY_CANCEL;
+    }
+    if(status == AuctionStatus.PROCESS || status == AuctionStatus.FAILED) { //group2 : 진행 중, 유찰
+      return AuctionStatusGroup.PROCESS_FAILED;
+    }
+    return (userid.equals(loginId)) ? AuctionStatusGroup.COMPLETED_MY : AuctionStatusGroup.COMPLETED_OTHER;
+  }
+
+  private Map<Long, BaseSalesHistoryResponse> fetchDetailedData(Map<AuctionStatusGroup, List<Long>> groups, Long userid) { //상태에 따른 분기 처리 및 쿼리 실행
+    Map<Long, BaseSalesHistoryResponse> resultData = new HashMap<>();
+
+    if (groups.containsKey(AuctionStatusGroup.READY_CANCEL)) { //쿼리: 준비, 취소 상태
+      salesHistoryQueryRepository.getSalesHistory(groups.get(AuctionStatusGroup.READY_CANCEL))
+          .forEach(data -> resultData.put(data.get("auctionId", Long.class), SalesHistoryResponse.from(data)));
+    }
+
+    if (groups.containsKey(AuctionStatusGroup.PROCESS_FAILED)) { //쿼리: 진행중, 실패 상태
+      salesHistoryQueryRepository.getProcessingSalesHistory(groups.get(AuctionStatusGroup.PROCESS_FAILED))
+          .forEach(data -> resultData.put(data.get("auctionId", Long.class), ProcessingSalesHistoryResponse.from(data)));
+    }
+
+    if (groups.containsKey(AuctionStatusGroup.COMPLETED_MY)) { //쿼리: 낙찰된 경우 (자신)
+      salesHistoryQueryRepository.getOwnerCompletedSalesHistory(groups.get(AuctionStatusGroup.COMPLETED_MY), userid)
+          .forEach(data -> resultData.put(data.get("auctionId", Long.class), OwnerCompletedSalesHistoryResponse.from(data)));
+    }
+
+    if (groups.containsKey(AuctionStatusGroup.COMPLETED_OTHER)) { //쿼리: 낙찰된 경우 (상대방)
+      salesHistoryQueryRepository.getCompletedSalesHistory(groups.get(AuctionStatusGroup.COMPLETED_OTHER))
+          .forEach(data -> resultData.put(data.get("auctionId", Long.class), CompletedSalesHistoryResponse.from(data)));
+    }
+
+    return resultData;
+  }
+
 }

--- a/src/main/java/com/windfall/domain/auction/enums/AuctionStatusGroup.java
+++ b/src/main/java/com/windfall/domain/auction/enums/AuctionStatusGroup.java
@@ -1,0 +1,8 @@
+package com.windfall.domain.auction.enums;
+
+public enum AuctionStatusGroup {
+  READY_CANCEL,
+  PROCESS_FAILED,
+  COMPLETED_MY,
+  COMPLETED_OTHER
+}

--- a/src/main/java/com/windfall/domain/user/repository/SalesHistoryQueryRepository.java
+++ b/src/main/java/com/windfall/domain/user/repository/SalesHistoryQueryRepository.java
@@ -1,0 +1,122 @@
+package com.windfall.domain.user.repository;
+
+import com.windfall.api.user.dto.response.saleshistory.SalesHistoryRaw;
+import com.windfall.domain.auction.entity.Auction;
+import jakarta.persistence.Tuple;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SalesHistoryQueryRepository extends JpaRepository<Auction, Long> {
+
+  @Query("""
+    SELECT
+    new com.windfall.api.user.dto.response.saleshistory.SalesHistoryRaw(
+    a.id,
+    a.status)
+    FROM Auction a
+    WHERE a.seller.id = :id AND
+    a.status = COALESCE(:filter, a.status) AND
+    a.activated = true
+    ORDER BY a.startedAt DESC
+  """)
+  Slice<SalesHistoryRaw> getRawSalesHistory(@Param("id") Long userId, @Param("filter") String filter, Pageable pageable);
+
+  @Query(value = """
+    SELECT
+    a.status AS status, -- 경매 상태 (예정, 취소 (기본))
+    a.id AS auctionId, -- 경매 id
+    a.title AS title, -- 경매 상품 이름
+    ai.image AS auctionImageUrl, -- 경매 상품 이미지 (첫 번째)
+    a.start_price AS startPrice, -- 경매 상품 시작가
+    DATE(a.started_at) AS startedAt -- 경매 시작 시간
+    FROM auction a
+    LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:ids)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+    WHERE a.id IN(:ids)
+  """, nativeQuery = true)
+  List<Tuple> getSalesHistory(@Param("ids") List<Long> ids);
+
+  @Query(value = """
+    SELECT
+    a.status AS status, -- 경매 상태 (완료, 사용자가 아닐 경우)
+    a.id AS auctionId, -- 경매 id
+    a.title AS title, -- 경매 상품 이름
+    ai.image AS auctionImageUrl, -- 경매 상품 사진
+    a.start_price AS startPrice, -- 경매 시작가
+    t.final_price AS endPrice, -- 낙찰가
+    ROUND(((a.start_price - t.final_price) / a.start_price) * 100) AS discountPercent, -- 할인율
+    DATE(a.started_at) AS startedAt, -- 경매 시작일
+    t.status AS tradeStatus -- 거래 상태
+    FROM auction a
+    JOIN trade t ON a.id = t.auction_id
+    LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i
+      WHERE i.auction_id IN (:ids)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+    WHERE a.id IN(:ids) AND (t.status = "PAYMENT_COMPLETED" OR t.status = "PURCHASE_CONFIRMED")
+  """, nativeQuery = true)
+  List<Tuple> getCompletedSalesHistory(@Param("ids") List<Long> ids);
+
+  @Query(value = """
+   SELECT
+   a.status AS status, -- 경매 상태 (완료, 사용자일 경우)
+   a.id AS auctionId, -- 경매 id
+   a.title AS title, -- 경매 상품 이름
+   ai.image AS auctionImageUrl, -- 경매 상품 사진
+   a.start_price AS startPrice, -- 경매 시작가
+   t.final_price AS endPrice, -- 낙찰가
+   ROUND(((a.start_price - t.final_price) / a.start_price) * 100) AS discountPercent, -- 할인율
+   DATE(a.started_at) AS startedAt, -- 경매 시작일
+   t.status AS tradeStatus, -- 거래 상태
+   cr.id AS roomId, -- 채팅방 id
+   COALESCE(SUM(cm.sender_id != :id AND cm.is_read = false), 0) AS unreadCount-- 안 읽은 채팅 개수
+   FROM auction a
+   JOIN trade t ON a.id = t.auction_id
+   JOIN chat_room cr ON t.id = cr.trade_id
+   LEFT JOIN chat_message cm ON cr.id = cm.chat_room_id
+   LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i
+      WHERE i.auction_id IN (:ids)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+   WHERE a.id IN(:ids) AND (t.status = "PAYMENT_COMPLETED" OR t.status = "PURCHASE_CONFIRMED")
+   GROUP BY a.status, a.id, a.title, ai.image, a.start_price, a.started_at, t.final_price, t.status, cr.id
+  """, nativeQuery = true)
+  List<Tuple> getOwnerCompletedSalesHistory(@Param("ids") List<Long> ids, @Param("id") Long userid);
+
+  @Query(value = """
+   SELECT
+   a.status AS status, -- 경매 상태 (진행중이거나 유찰중일 경우)
+   a.id AS auctionId, -- 경매 id
+   a.title AS title, -- 경매 상품 이름
+   ai.image AS auctionImageUrl, -- 경매 상품 사진
+   a.start_price AS startPrice, -- 경매 시작가
+   a.current_price AS currentPrice, -- 현재가
+   ROUND(((a.start_price - a.current_price) / a.start_price) * 100, 0) AS discountPercent, -- 할인율
+   DATE(a.started_at) AS startedAt -- 경매 시작일
+   FROM auction a
+   LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i
+      WHERE i.auction_id IN (:ids)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+   WHERE a.id IN(:ids)
+  """, nativeQuery = true)
+  List<Tuple> getProcessingSalesHistory(@Param("ids") List<Long> ids);
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #48

## 📝 변경 사항
### AS-IS
- 판매내역 조회 api의 부재

### TO-BE
- 판매내여 조회 api 구현
- UserDetails가 구현되지 않았음에 따라 임시적으로 loginId를 QueryParameter로 정의

## ⚠️주의 : 코드 가독성이 별로 좋지 않습니다. 코드를 보고 의문이 드실경우, 이 내용을 참고해주시면 감사하겠습니다.

읽어도 이해가 안 간다면 질문을 던져주세요! 피드백 무조건 환영입니다

### 1. JPQL을 두고 Native Query를 사용하는 이유
-> JPQL은 인라인뷰가 되지 않는다. 

- 가장 첫 번째 이미지를 꺼내올 때 서브쿼리 방식, 인라인 뷰 방식이 있는데, 서브쿼리 방식으로는 JPQL문법을 지원하지만 행마다 쿼리를 실행해 마치 N+1처럼 동작하는 효과가 발생합니다. 성능 저하의 원인이므로 차라리 인라인뷰로 테이블을 먼저 세팅한 뒤 조인하여 필요한 값을 꺼내는 방식이 더 성능 저하를 발생시키지 않는다고 판단하였습니다. 그로 인해 인라인뷰가 안되는 JPQL대신 Native Query를 사용하여 유지보수보단 성능을 더 강화하는 전략을 선택했습니다.


-> **쿼리단에서 처리하는게 맞는것 같아보임**

- 서비스단에서 이 부분을 처리하려고 하면 매우 복잡한 로직 및 쿼리의 세분화가 예상되어 쿼리 I/O가 매우 증가가 예상되었습니다. 또한 경매 상태별로 dto 요구사항이 달라 이에 따른 분기 처리 로직도 담겨있어 서비스단에서 처리하려고 하면 복잡도는 더 가중될 것이라 예상하였습니다. 중복된 네이티브 쿼리는 QueryDSL로 보완 및 유지보수가 가능할 여지가 있으므로 현재는 이렇게 설계하는것이 최선이라고 생각하였습니다.

### 2. DTO를 상속구조로 사용하는 이유
-> **dto 정의를 쉽게 하고, 유지보수의 번거로움을 최소화**

- 공통 응답값을 묶어 dto정의를 쉽게 하고, 공통 데이터에 대한 변경사항이 생길 경우 부모 필드만 변경하면 되므로 유지보수가 용이하다고 생각되어 해당 방식을 고려하였습니다.

-> **경매 상태별로 요구하는 데이터가 다름.**
- 경매 상태별로 요구하는 데이터, 즉 dto 스펙이 달라지므로 한 응답에 여러 형태의 데이터를 집어넣으려면 상속 구조로 설계하여 서로 다른 형태의 데이터를 넣을 수 있도록 함에 목적이 있습니다.

### 3. 서비스단에서의 예외처리 위험성
- 읽기 전용 쿼리이므로 유저의 유무만 판단하고, 나머지 없는 데이터에 대해선 INNER JOIN과 OUTER JOIN으로 인하여 표시하지 않거나 NULL로 표시하게 됩니다. 따라서 예외처리가 필요하지 않을것이라고 판단됩니다.

### 4. 쿼리 결과를 Tuple로 받은 이유
-> **1번의 이유로 인하여 Native Query를 선택하게 되면서 프로젝션에 대한 제약사항 발생**
- 네이티브 쿼리는 기본적으로 dto projection을 지원하지 않기 때문에, 다른 방안을 고안해야 했습니다. 

- @SqlResultSetMapping 적용: 엔티티에 매핑을 위한 쿼리를 작성, 타입 추론이 필요없고 프로젝션이 가능하지만 엔티티 코드와 네이티브 쿼리에 추가 코드를 구성해야하므로 가독성이 매우 떨어집니다.

- Object[]로 직접 데이터 매핑: 쿼리 결과를 Object[]로 받게 되면, 타입 추론과 어떤 데이터가 들어오는지 개발자가 직접 추론하며 dto에 매핑을 해야합니다. 매핑 과정에서 실수할 가능성이 매우 높고, 컴파일 환경에서 에러가 발견되지 않는다는 단점이 있습니다.

- Tuple로 받아서 dto로 변환: 쿼리 결과를 Tuple로 받게 되면 Object와 다르게 명시된 컬럼을 가져올 수 있습니다. 대신 어떤 타입이 들어오는지는 타입 추론을 해야하는 번거로움이 아직 있습니다. 그러나 서비스 레이어에서는 간단히 tuple만 넣고 조립 과정을 dto에 위임하면 되고, 타입 추론이 dto와 맞지 않을경우 컴파일 단계에서 오류를 보여줘 실수를 방지할 수 있다는 장점이 있어 해당 방식을 고려하였습니다. 또한 타 개발자가 보았을 때 어떤 이 dto는 데이터를 가지고 가는지 명시적으로 알 수 있어 가독성 면에서도 좋다고 생각합니다.

### 5. 쿼리 부하 가능성
- 현재 사용되고 있는 네이티브 쿼리는 분기처리용 쿼리 1개 + 상태별 최적화 쿼리 4개로 구성되어있습니다. 모든 상태가 포함되어있는 경우 최대 5개의 쿼리가 발생하게 됩니다. 네트워크 I/O를 조금 더 소모하더라도 복잡한 JOIN으로 인한 성능 저하가 더 높다고 판단되었고, 각 쿼리에 인덱스를 탈 수 있도록 PK 기반으로 검색할 수 있도록 개선하였습니다. 분기처리용 쿼리에는 추후에 복합 인덱스를 적용하여 처리시간을 더 단축할 계획입니다.


## 테스트 결과
결과에서 나오는 null은 무시해주세요

### 나의 판매내역을 봤을 때
<img width="1680" height="627" alt="image" src="https://github.com/user-attachments/assets/a8c6fa99-6e6e-4dba-bebe-e9f292a4f5ee" />

<img width="1640" height="783" alt="image" src="https://github.com/user-attachments/assets/d60b3faf-6382-47c6-8bad-aa1487c01eab" />

### 상대방의 판매내역을 봤을 때
상태가 COMPLETED라도 자신의 판매내역이 아니기 때문에 채팅방의 정보를 보여주지 않습니다.
<img width="1114" height="742" alt="image" src="https://github.com/user-attachments/assets/428e2b9b-eddd-409d-9f43-b5f8fe36a5f8" />

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
주의사항을 꼭 읽어주세요!
코드가 매우 길고, 로직이 복잡해서 가독성이 많이 떨어집니다. 양해 부탁드립니다.
부족한 실력 탓인지 코드 구성에 미숙한 부분이 많습니다. 많은 피드백 부탁합니다.