### PR TITLE
[Feature] 구매내역 조회 api 구현

### DIFF
--- a/src/main/java/com/windfall/api/mypage/controller/MyPageController.java
+++ b/src/main/java/com/windfall/api/mypage/controller/MyPageController.java
@@ -1,0 +1,39 @@
+package com.windfall.api.mypage.controller;
+
+import com.windfall.api.mypage.dto.purchasehistory.BasePurchaseHistory;
+import com.windfall.api.mypage.service.PurchaseHistoryService;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import com.windfall.global.response.SliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/me")
+public class MyPageController implements MyPageSpecification{
+
+  private final PurchaseHistoryService purchaseHistoryService;
+
+  @GetMapping("/purchases")
+  public ApiResponse<SliceResponse<BasePurchaseHistory>> getMyPurchaseHistory(
+      @PageableDefault(page = 0, size = 10) Pageable pageable,
+      @RequestParam(required = false) String filter,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ){
+    Long userId = userDetails.getUserId();
+    SliceResponse<BasePurchaseHistory> response = purchaseHistoryService.getPurchaseHistories(userId, filter, pageable);
+
+    return ApiResponse.ok("구매내역 조회에 성공하였습니다.", response);
+
+  }
+
+
+
+}

--- a/src/main/java/com/windfall/api/mypage/controller/MyPageSpecification.java
+++ b/src/main/java/com/windfall/api/mypage/controller/MyPageSpecification.java
@@ -1,0 +1,22 @@
+package com.windfall.api.mypage.controller;
+
+import com.windfall.api.mypage.dto.purchasehistory.BasePurchaseHistory;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import com.windfall.global.response.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "MyPage", description = "마이페이지 API")
+public interface MyPageSpecification {
+
+  @Operation(summary = "나의 구매내역 조회", description = "자신의 구매내역을 조회합니다.")
+  ApiResponse<SliceResponse<BasePurchaseHistory>> getMyPurchaseHistory(@PageableDefault(page = 0, size = 10) Pageable pageable,
+      @RequestParam(required = false) String filter,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  );
+}

--- a/src/main/java/com/windfall/api/mypage/dto/purchasehistory/BasePurchaseHistory.java
+++ b/src/main/java/com/windfall/api/mypage/dto/purchasehistory/BasePurchaseHistory.java
@@ -1,0 +1,55 @@
+package com.windfall.api.mypage.dto.purchasehistory;
+import com.windfall.api.chat.dto.response.info.ChatInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+@Schema(
+    subTypes = { // 자식 클래스
+        PurchaseHistoryResponse.class,
+        ConfirmedPurchaseHistoryResponse.class
+    }
+)
+public abstract class BasePurchaseHistory {
+
+  @Schema(description = "경매 상태")
+  private final String status;
+
+  @Schema(description = "경매 id")
+  private final Long auctionId;
+
+  @Schema(description = "경매 제목")
+  private final String title;
+
+  @Schema(description = "경매 이미지 url")
+  private final String auctionImageUrl;
+
+  @Schema(description = "경매 시작가")
+  private final int startPrice;
+
+  @Schema(description = "낙찰가")
+  private final int endPrice;
+
+  @Schema(description = "하락 퍼센트")
+  private final int discountPercent;
+
+  @Schema(description = "낙찰 일시")
+  private final LocalDate purchasedDate;
+
+  @Schema(description = "채팅 정보")
+  private final ChatInfo chatInfo;
+
+  public BasePurchaseHistory(String status, Long auctionId, String title, String auctionImageUrl,
+      int startPrice, int endPrice, int discountPercent, LocalDate purchasedDate, Long roomId, int unreadCount) {
+    this.status = status;
+    this.auctionId = auctionId;
+    this.title = title;
+    this.auctionImageUrl = auctionImageUrl;
+    this.startPrice = startPrice;
+    this.endPrice = endPrice;
+    this.discountPercent = discountPercent;
+    this.purchasedDate = purchasedDate;
+    this.chatInfo = new ChatInfo(roomId, unreadCount);
+  }
+}

--- a/src/main/java/com/windfall/api/mypage/dto/purchasehistory/ConfirmedPurchaseHistoryResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/purchasehistory/ConfirmedPurchaseHistoryResponse.java
@@ -1,0 +1,43 @@
+package com.windfall.api.mypage.dto.purchasehistory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ConfirmedPurchaseHistoryResponse extends BasePurchaseHistory{
+
+  @Schema(description = "리뷰 Id (리뷰가 없을경우 0으로 반환)")
+  private final Long reviewId;
+
+  @Builder
+  public ConfirmedPurchaseHistoryResponse(String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, int endPrice, int discountPercent,
+      LocalDate purchasedDate, Long roomId, int unreadCount, Long reviewId) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, endPrice, discountPercent,
+        purchasedDate, roomId, unreadCount);
+    this.reviewId = reviewId;
+  }
+
+  public static ConfirmedPurchaseHistoryResponse from(Tuple tuple){
+    return ConfirmedPurchaseHistoryResponse
+        .builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .endPrice(tuple.get("endPrice", Long.class).intValue())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .purchasedDate(tuple.get("purchasedDate", Date.class).toLocalDate())
+        .roomId(tuple.get("roomId", Long.class))
+        .unreadCount(tuple.get("unreadCount", BigDecimal.class).intValue())
+        .reviewId(tuple.get("reviewId", Long.class))
+        .build();
+  }
+
+}

--- a/src/main/java/com/windfall/api/mypage/dto/purchasehistory/PurchaseGroupsDTO.java
+++ b/src/main/java/com/windfall/api/mypage/dto/purchasehistory/PurchaseGroupsDTO.java
@@ -1,0 +1,11 @@
+package com.windfall.api.mypage.dto.purchasehistory;
+
+import com.windfall.domain.trade.enums.TradeStatus;
+import java.util.List;
+import java.util.Map;
+
+public record PurchaseGroupsDTO(
+    Map<TradeStatus, List<Long>> tradeGroups,
+    Map<TradeStatus, List<Long>> auctionGroups
+) {
+}

--- a/src/main/java/com/windfall/api/mypage/dto/purchasehistory/PurchaseHistoryRaw.java
+++ b/src/main/java/com/windfall/api/mypage/dto/purchasehistory/PurchaseHistoryRaw.java
@@ -1,0 +1,11 @@
+package com.windfall.api.mypage.dto.purchasehistory;
+
+import com.windfall.domain.trade.enums.TradeStatus;
+
+public record PurchaseHistoryRaw(
+    Long auctionId,
+    Long tradeId,
+    TradeStatus status
+) {
+
+}

--- a/src/main/java/com/windfall/api/mypage/dto/purchasehistory/PurchaseHistoryResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/purchasehistory/PurchaseHistoryResponse.java
@@ -1,0 +1,38 @@
+package com.windfall.api.mypage.dto.purchasehistory;
+
+import com.windfall.api.user.dto.response.saleshistory.ProcessingSalesHistoryResponse;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PurchaseHistoryResponse extends BasePurchaseHistory{
+
+  @Builder
+  public PurchaseHistoryResponse(String status, Long auctionId, String title,
+      String auctionImageUrl,
+      int startPrice, int endPrice, int discountPercent, LocalDate purchasedDate, Long roomId,
+      int unreadCount) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, endPrice, discountPercent,
+        purchasedDate, roomId, unreadCount);
+  }
+
+  public static PurchaseHistoryResponse from(Tuple tuple){
+    return PurchaseHistoryResponse
+        .builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .endPrice(tuple.get("endPrice", Long.class).intValue())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .purchasedDate(tuple.get("purchasedDate", Date.class).toLocalDate())
+        .roomId(tuple.get("roomId", Long.class))
+        .unreadCount(tuple.get("unreadCount", BigDecimal.class).intValue())
+        .build();
+  }
+}

--- a/src/main/java/com/windfall/api/mypage/service/PurchaseHistoryService.java
+++ b/src/main/java/com/windfall/api/mypage/service/PurchaseHistoryService.java
@@ -66,8 +66,6 @@ public class PurchaseHistoryService {
     Map<TradeStatus, List<Long>> tradeGroups = groups.tradeGroups();
     Map<TradeStatus, List<Long>> auctionGroups = groups.auctionGroups();
 
-    System.out.println(tradeGroups.get(TradeStatus.PAYMENT_COMPLETED));
-
     if(tradeGroups.containsKey(TradeStatus.PAYMENT_COMPLETED)){ //결제 완료
       purchaseHistoryQueryRepository.getPurchaseHistory(userid, tradeGroups.get(TradeStatus.PAYMENT_COMPLETED), auctionGroups.get(TradeStatus.PAYMENT_COMPLETED)).forEach(
       data -> resultData.put(data.get("auctionId", Long.class), PurchaseHistoryResponse.from(data)));

--- a/src/main/java/com/windfall/api/mypage/service/PurchaseHistoryService.java
+++ b/src/main/java/com/windfall/api/mypage/service/PurchaseHistoryService.java
@@ -1,0 +1,94 @@
+package com.windfall.api.mypage.service;
+
+import com.windfall.api.mypage.dto.purchasehistory.BasePurchaseHistory;
+import com.windfall.api.mypage.dto.purchasehistory.ConfirmedPurchaseHistoryResponse;
+import com.windfall.api.mypage.dto.purchasehistory.PurchaseGroupsDTO;
+import com.windfall.api.mypage.dto.purchasehistory.PurchaseHistoryRaw;
+import com.windfall.api.mypage.dto.purchasehistory.PurchaseHistoryResponse;
+import com.windfall.domain.mypage.repository.PurchaseHistoryQueryRepository;
+import com.windfall.domain.trade.enums.TradeStatus;
+import com.windfall.global.response.SliceResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PurchaseHistoryService {
+
+  private final PurchaseHistoryQueryRepository purchaseHistoryQueryRepository;
+
+  @Transactional
+  public SliceResponse<BasePurchaseHistory> getPurchaseHistories(Long myId, String filter, Pageable pageable){
+
+    //1. rawdata 추출
+    Slice<PurchaseHistoryRaw> rawData = purchaseHistoryQueryRepository.getRawPurchaseHistory(myId, filter, pageable);
+
+    //2. 순서 저장
+    List<Long> dataSequence = rawData.stream().map(PurchaseHistoryRaw::auctionId).toList();
+
+    //3. 분기 작업 (그룹화)
+    PurchaseGroupsDTO groups = groupingData(rawData.getContent());
+
+    //4. 상태 별 쿼리 실행
+    Map<Long, BasePurchaseHistory> resultData = fetchDetailedData(groups, myId);
+
+    //5. 순서 재조립
+    List<BasePurchaseHistory> resultContent = orderByResults(dataSequence, resultData);
+
+    //6. 다시 slice로 반환
+    Slice<BasePurchaseHistory> resultSlice = toSlice(resultContent, rawData);
+
+    return SliceResponse.from(resultSlice);
+  }
+
+  private PurchaseGroupsDTO groupingData(List<PurchaseHistoryRaw> rawData){
+    Map<TradeStatus, List<Long>> tradeGroups = new HashMap<>();
+    Map<TradeStatus, List<Long>> auctionGroups = new HashMap<>();
+    rawData.forEach(raw ->
+    {
+      tradeGroups.computeIfAbsent(raw.status(), k -> new ArrayList<>()).add(raw.tradeId()); //이거까지 담는 이유: trade 상태별로 쿼리를 실행해야하기 때문에
+      auctionGroups.computeIfAbsent(raw.status(), k -> new ArrayList<>()).add(raw.auctionId());
+    });
+
+    return new PurchaseGroupsDTO(tradeGroups, auctionGroups);
+  }
+
+  private Map<Long, BasePurchaseHistory> fetchDetailedData(PurchaseGroupsDTO groups, Long userid){
+    Map<Long, BasePurchaseHistory> resultData = new HashMap<>();
+    Map<TradeStatus, List<Long>> tradeGroups = groups.tradeGroups();
+    Map<TradeStatus, List<Long>> auctionGroups = groups.auctionGroups();
+
+    System.out.println(tradeGroups.get(TradeStatus.PAYMENT_COMPLETED));
+
+    if(tradeGroups.containsKey(TradeStatus.PAYMENT_COMPLETED)){ //결제 완료
+      purchaseHistoryQueryRepository.getPurchaseHistory(userid, tradeGroups.get(TradeStatus.PAYMENT_COMPLETED), auctionGroups.get(TradeStatus.PAYMENT_COMPLETED)).forEach(
+      data -> resultData.put(data.get("auctionId", Long.class), PurchaseHistoryResponse.from(data)));
+    }
+    if(tradeGroups.containsKey(TradeStatus.PURCHASE_CONFIRMED)){ //구매 확정
+      purchaseHistoryQueryRepository.getConfirmedPurchaseHistory(userid, tradeGroups.get(TradeStatus.PURCHASE_CONFIRMED), auctionGroups.get(TradeStatus.PURCHASE_CONFIRMED)).forEach(
+          data -> resultData.put(data.get("auctionId", Long.class), ConfirmedPurchaseHistoryResponse.from(data)));
+    }
+
+    return resultData;
+  }
+
+  private List<BasePurchaseHistory> orderByResults(List<Long> dataSequence, Map<Long, BasePurchaseHistory> resultData){
+    return dataSequence.stream().map(resultData::get).toList();
+  }
+
+  private Slice<BasePurchaseHistory> toSlice(List<BasePurchaseHistory> resultContent, Slice<?> rawData){
+    return new SliceImpl<>(
+        resultContent,
+        rawData.getPageable(),
+        rawData.hasNext()
+    );
+  }
+}

--- a/src/main/java/com/windfall/domain/mypage/repository/PurchaseHistoryQueryRepository.java
+++ b/src/main/java/com/windfall/domain/mypage/repository/PurchaseHistoryQueryRepository.java
@@ -1,0 +1,88 @@
+package com.windfall.domain.mypage.repository;
+
+import com.windfall.api.mypage.dto.purchasehistory.PurchaseHistoryRaw;
+import com.windfall.api.user.dto.response.saleshistory.SalesHistoryRaw;
+import com.windfall.domain.trade.entity.Trade;
+import jakarta.persistence.Tuple;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PurchaseHistoryQueryRepository extends JpaRepository<Trade, Long> {
+
+  @Query("""
+    SELECT
+    new com.windfall.api.mypage.dto.purchasehistory.PurchaseHistoryRaw(
+    a.id,
+    t.id,
+    t.status)
+    FROM Trade t
+    JOIN Auction a ON t.auction.id = a.id
+    WHERE t.buyerId = :id AND
+    t.status = COALESCE(:filter, t.status) AND
+    (t.status = "PAYMENT_COMPLETED" OR t.status = "PURCHASE_CONFIRMED")
+    ORDER BY t.createDate DESC
+  """)
+  Slice<PurchaseHistoryRaw> getRawPurchaseHistory(@Param("id") Long userId, @Param("filter") String filter, Pageable pageable);
+
+  @Query(value = """
+    SELECT
+    t.status AS status, -- 거래 상태
+    a.id AS auctionId, -- 경매 id
+    a.title AS title, -- 상품 이름
+    ai.image AS auctionImageUrl, -- 상품 대표 사진
+    a.start_price AS startPrice, -- 시작가
+    t.final_price AS endPrice, -- 낙찰가
+    ROUND(((a.start_price - t.final_price) / a.start_price) * 100) AS discountPercent, -- 할인율
+    DATE(t.create_date) AS purchasedDate, -- 낙찰 일시
+    cr.id AS roomId, -- 채팅방 id
+    COALESCE(SUM(cm.sender_id != :id AND cm.is_read = false), 0) AS unreadCount -- 안 읽은 채팅 개수
+    FROM trade t
+    JOIN auction a ON t.auction_id = a.id
+    JOIN chat_room cr ON cr.trade_id = t.id
+    LEFT JOIN chat_message cm ON cm.chat_room_id = cr.id
+    LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:auctionIds)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+    WHERE t.id IN(:ids)
+    GROUP BY t.status, a.id, a.title, ai.image, a.start_price, t.final_price, t.create_date, cr.id
+""", nativeQuery = true)
+  List<Tuple> getPurchaseHistory(@Param("id") Long userid, @Param("ids") List<Long> ids, @Param("auctionIds") List<Long> auctionIds);
+
+  @Query(value = """
+    SELECT
+    t.status AS status, -- 거래 상태
+    a.id AS auctionId, -- 경매 id
+    a.title AS title, -- 상품 이름
+    ai.image AS auctionImageUrl, -- 상품 대표 사진
+    a.start_price AS startPrice, -- 시작가
+    t.final_price AS endPrice, -- 낙찰가
+    ROUND(((a.start_price - t.final_price) / a.start_price) * 100) AS discountPercent, -- 할인율
+    DATE(t.create_date) AS purchasedDate, -- 낙찰 일시
+    cr.id AS roomId, -- 채팅방 id
+    COALESCE(SUM(cm.sender_id != :id AND cm.is_read = false), 0) AS unreadCount, -- 안 읽은 채팅 개수
+    COALESCE(r.id, 0) AS reviewId -- 리뷰 id
+    FROM trade t
+    JOIN auction a ON t.auction_id = a.id
+    JOIN chat_room cr ON cr.trade_id = t.id
+    LEFT JOIN review r ON r.trade_id = t.id
+    LEFT JOIN chat_message cm ON cm.chat_room_id = cr.id
+    LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:auctionIds)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+    WHERE t.id IN(:ids)
+    GROUP BY t.status, a.id, a.title, ai.image, a.start_price, t.final_price, t.create_date, cr.id, r.id
+""", nativeQuery = true)
+  List<Tuple> getConfirmedPurchaseHistory(@Param("id") Long userid, @Param("ids") List<Long> ids, @Param("auctionIds") List<Long> auctionIds);
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #91

## 📝 변경 사항
### AS-IS
- 구매내역 조회 api의 부재

### TO-BE
- 이전 판매 내역 조회 api와 비슷하게 구현하였습니다.
- dto상속구조를 유지하는 이유는 우발적 중복이 아닌 진짜 중복이라 판단되어 나뒀습니다.
- 이유: 와이어프레임을 보시다시피 데이터의 뿌리는 경매에서 옵니다. 각 api들은 판매, 구매, 찜, 알림 설정 내역, 최근 본 내역 모두 빠지지않고 경매 정보에 대해 보여주는 목적에 있기 때문에 진짜 중복이라고 판단하였습니다.

## 🔍 테스트
- [] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
시간이 급해서 테스트를 얼마 못했습니다. 추후 리팩토링때 세세하게 해보겠습니다. (일단 작동되는 코드로 제출합니다.)
<img width="906" height="584" alt="image" src="https://github.com/user-attachments/assets/249941db-a295-4510-b642-e036f1f26c17" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
쿼리 구조에 대해서 봐주시면 감사하겠습니다.
조금 빠르게 짜서 실수한 부분이 있을수도 있습니다.