### PR TITLE
[Feature] 채팅방 상세조회 API 구현 (메타 정보 + 메시지 커서 페이징)

### DIFF
--- a/src/main/java/com/windfall/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatRoomController.java
@@ -1,12 +1,16 @@
 package com.windfall.api.chat.controller;
 
 import com.windfall.api.chat.dto.request.enums.ChatRoomScope;
+import com.windfall.api.chat.dto.response.ChatRoomDetailResponse;
 import com.windfall.api.chat.dto.response.ChatRoomListResponse;
 import com.windfall.api.chat.service.ChatRoomService;
+import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,5 +31,19 @@ public class ChatRoomController implements ChatRoomSpecification {
 
     List<ChatRoomListResponse> response = chatRoomService.getChatRooms(userId, scope);
     return ApiResponse.ok("채팅방 목록이 조회되었습니다.", response);
+  }
+
+  @Override
+  @GetMapping("/{chatRoomId}/messages")
+  public ApiResponse<ChatRoomDetailResponse> getChatRoomDetail(
+      @PathVariable Long chatRoomId,
+      @RequestParam(required = false) Long cursor,
+      @RequestParam(defaultValue = "20") int size,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    Long userId = userDetails.getUserId();
+    ChatRoomDetailResponse response = chatRoomService.getChatRoomDetail(userId, chatRoomId, cursor,
+        size);
+    return ApiResponse.ok("채팅방 상세 정보가 조회되었습니다.", response);
   }
 }

--- a/src/main/java/com/windfall/api/chat/controller/ChatRoomSpecification.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatRoomSpecification.java
@@ -1,12 +1,16 @@
 package com.windfall.api.chat.controller;
 
 import com.windfall.api.chat.dto.request.enums.ChatRoomScope;
+import com.windfall.api.chat.dto.response.ChatRoomDetailResponse;
 import com.windfall.api.chat.dto.response.ChatRoomListResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Chat", description = "채팅방 API")
@@ -29,6 +33,28 @@ public interface ChatRoomSpecification {
 
       @Parameter(description = "사용자 ID(임시, 로그인 붙이면 제거 예정)", example = "1")
       @RequestParam(defaultValue = "1") Long userId
+  );
+
+  @Operation(
+      summary = "채팅방 상세 조회 (메타 정보 + 메시지 내용 커서 페이징)",
+      description = """
+          채팅방 상세 화면에 필요한 정보를 조회합니다.
+          - 상단 메타(상대방/경매/거래 정보) + 메시지 목록(cursor 기반)을 한 번에 반환합니다.
+          - cursor가 없으면 최신 메시지부터 size 만큼 반환합니다.
+          - nextCursor를 다음 요청에 전달하면 더 과거 메시지를 조회합니다.
+          """
+  )
+  ApiResponse<ChatRoomDetailResponse> getChatRoomDetail(
+      @Parameter(description = "채팅방 ID", example = "1")
+      @PathVariable Long chatRoomId,
+
+      @Parameter(description = "커서(이전 페이지의 nextCursor)", example = "120")
+      @RequestParam(required = false) Long cursor,
+
+      @Parameter(description = "조회 개수", example = "20")
+      @RequestParam(defaultValue = "20") int size,
+
+      @AuthenticationPrincipal CustomUserDetails userDetails
   );
 
 }

--- a/src/main/java/com/windfall/api/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/ChatRoomDetailResponse.java
@@ -1,6 +1,6 @@
 package com.windfall.api.chat.dto.response;
 
-import com.windfall.api.chat.dto.response.info.ChatMessageItem;
+import com.windfall.api.chat.dto.response.info.ChatMessageInfo;
 import com.windfall.api.chat.dto.response.info.ChatRoomMetaInfo;
 import com.windfall.global.response.CursorResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,9 +12,9 @@ public record ChatRoomDetailResponse(
     ChatRoomMetaInfo chatRoomMeta,
 
     @Schema(description = "메시지 커서 페이징")
-    CursorResponse<ChatMessageItem> messages
+    CursorResponse<ChatMessageInfo> messages
 ) {
-  public static ChatRoomDetailResponse of(ChatRoomMetaInfo meta, CursorResponse<ChatMessageItem> messages) {
+  public static ChatRoomDetailResponse of(ChatRoomMetaInfo meta, CursorResponse<ChatMessageInfo> messages) {
     return new ChatRoomDetailResponse(meta, messages);
   }
 }

--- a/src/main/java/com/windfall/api/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/ChatRoomDetailResponse.java
@@ -1,0 +1,20 @@
+package com.windfall.api.chat.dto.response;
+
+import com.windfall.api.chat.dto.response.info.ChatMessageItem;
+import com.windfall.api.chat.dto.response.info.ChatRoomMetaInfo;
+import com.windfall.global.response.CursorResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 상세 조회 응답 DTO")
+public record ChatRoomDetailResponse(
+
+    @Schema(description = "채팅방 메타 정보")
+    ChatRoomMetaInfo chatRoomMeta,
+
+    @Schema(description = "메시지 커서 페이징")
+    CursorResponse<ChatMessageItem> messages
+) {
+  public static ChatRoomDetailResponse of(ChatRoomMetaInfo meta, CursorResponse<ChatMessageItem> messages) {
+    return new ChatRoomDetailResponse(meta, messages);
+  }
+}

--- a/src/main/java/com/windfall/api/chat/dto/response/info/ChatMessageInfo.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/info/ChatMessageInfo.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "채팅 메시지 정보 DTO")
-public record ChatMessageItem(
+public record ChatMessageInfo(
 
     @Schema(description = "메시지 ID")
     Long messageId,

--- a/src/main/java/com/windfall/api/chat/dto/response/info/ChatMessageItem.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/info/ChatMessageItem.java
@@ -1,0 +1,34 @@
+package com.windfall.api.chat.dto.response.info;
+
+import com.windfall.domain.chat.enums.ChatMessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "채팅 메시지 정보 DTO")
+public record ChatMessageItem(
+
+    @Schema(description = "메시지 ID")
+    Long messageId,
+
+    @Schema(description = "보낸 사람 ID")
+    Long senderId,
+
+    @Schema(description = "내 메시지 여부")
+    boolean isMine,
+
+    @Schema(description = "메시지 타입")
+    ChatMessageType messageType,
+
+    @Schema(description = "텍스트 내용(TEXT일 때)")
+    String content,
+
+    @Schema(description = "이미지 URL 목록(IMAGE일 때)")
+    List<String> imageUrls,
+
+    @Schema(description = "읽음 여부(상대방이 읽었는지)")
+    boolean isRead,
+
+    @Schema(description = "전송 시각")
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/com/windfall/api/chat/dto/response/info/ChatRoomMetaInfo.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/info/ChatRoomMetaInfo.java
@@ -1,0 +1,26 @@
+package com.windfall.api.chat.dto.response.info;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 상세 메타 정보 DTO")
+public record ChatRoomMetaInfo(
+
+    @Schema(description = "채팅방 ID")
+    Long chatRoomId,
+
+    @Schema(description = "경매 상품 정보")
+    AuctionInfo auction,
+
+    @Schema(description = "상대방 정보")
+    PartnerInfo partner,
+
+    @Schema(description = "거래 정보")
+    TradeInfo trade
+
+) {
+
+  public static ChatRoomMetaInfo of(Long chatRoomId, AuctionInfo auction, PartnerInfo partner,
+      TradeInfo trade) {
+    return new ChatRoomMetaInfo(chatRoomId, auction, partner, trade);
+  }
+}

--- a/src/main/java/com/windfall/api/chat/dto/response/info/TradeInfo.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/info/TradeInfo.java
@@ -5,6 +5,10 @@ import java.time.LocalDateTime;
 
 @Schema(description = "거래 정보 DTO")
 public record TradeInfo(
+
+    @Schema(description = "거래 ID")
+    Long tradeId,
+
     @Schema(description = "최종 구매가")
     Long finalPrice,
 
@@ -12,7 +16,7 @@ public record TradeInfo(
     LocalDateTime purchasedAt
 
 ) {
-  public static TradeInfo of(Long finalPrice, LocalDateTime purchasedAt) {
-    return new TradeInfo(finalPrice, purchasedAt);
+  public static TradeInfo of(Long tradeId, Long finalPrice, LocalDateTime purchasedAt) {
+    return new TradeInfo(tradeId, finalPrice, purchasedAt);
   }
 }

--- a/src/main/java/com/windfall/api/chat/dto/response/info/TradeInfo.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/info/TradeInfo.java
@@ -8,7 +8,7 @@ public record TradeInfo(
     @Schema(description = "최종 구매가")
     Long finalPrice,
 
-    @Schema(description = "구매일(결제 완료/구매확정 시점)")
+    @Schema(description = "구매일(결제 완료 시점)")
     LocalDateTime purchasedAt
 
 ) {

--- a/src/main/java/com/windfall/api/chat/dto/response/info/TradeInfo.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/info/TradeInfo.java
@@ -1,0 +1,18 @@
+package com.windfall.api.chat.dto.response.info;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "거래 정보 DTO")
+public record TradeInfo(
+    @Schema(description = "최종 구매가")
+    Long finalPrice,
+
+    @Schema(description = "구매일(결제 완료/구매확정 시점)")
+    LocalDateTime purchasedAt
+
+) {
+  public static TradeInfo of(Long finalPrice, LocalDateTime purchasedAt) {
+    return new TradeInfo(finalPrice, purchasedAt);
+  }
+}

--- a/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
@@ -37,7 +37,7 @@ public class ChatRoomService {
 
     User me = userService.getUserById(userId);
 
-    List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomForList(me.getId(), scope);
+    List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomForList(me.getId(), scope.name());
 
     if (chatRooms.isEmpty()) {
       return List.of();

--- a/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
@@ -15,6 +15,8 @@ import com.windfall.domain.chat.repository.ChatRoomRepository;
 import com.windfall.domain.trade.entity.Trade;
 import com.windfall.domain.trade.enums.TradeStatus;
 import com.windfall.domain.user.entity.User;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -90,6 +92,12 @@ public class ChatRoomService {
       int size) {
 
     User me = userService.getUserById(userId);
+
+    ChatRoom chatRoom = chatRoomRepository.findDetailById(chatRoomId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+
+    Trade trade = chatRoom.getTrade();
+    Auction auction = trade.getAuction();
 
   }
 

--- a/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
@@ -8,6 +8,7 @@ import com.windfall.api.chat.dto.response.info.LastMessageInfo;
 import com.windfall.api.chat.dto.response.info.PartnerInfo;
 import com.windfall.api.user.service.UserService;
 import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.entity.AuctionImage;
 import com.windfall.domain.auction.repository.AuctionImageRepository;
 import com.windfall.domain.chat.entity.ChatRoom;
 import com.windfall.domain.chat.repository.ChatMessageRepository;
@@ -115,7 +116,11 @@ public class ChatRoomService {
 
     PartnerInfo partnerInfo = PartnerInfo.from(partnerUser);
 
+    String thumbUrl = auctionImageRepository.findTop1ByAuctionIdOrderByIdAsc(auction.getId())
+        .map(AuctionImage::getImage)
+        .orElse(null);
 
+    AuctionInfo auctionInfo = AuctionInfo.of(auction, thumbUrl);
   }
 
   private boolean isVisibleTradeStatus(ChatRoom cr) {

--- a/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
@@ -4,8 +4,10 @@ import com.windfall.api.chat.dto.request.enums.ChatRoomScope;
 import com.windfall.api.chat.dto.response.ChatRoomDetailResponse;
 import com.windfall.api.chat.dto.response.ChatRoomListResponse;
 import com.windfall.api.chat.dto.response.info.AuctionInfo;
+import com.windfall.api.chat.dto.response.info.ChatRoomMetaInfo;
 import com.windfall.api.chat.dto.response.info.LastMessageInfo;
 import com.windfall.api.chat.dto.response.info.PartnerInfo;
+import com.windfall.api.chat.dto.response.info.TradeInfo;
 import com.windfall.api.user.service.UserService;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.entity.AuctionImage;
@@ -121,6 +123,11 @@ public class ChatRoomService {
         .orElse(null);
 
     AuctionInfo auctionInfo = AuctionInfo.of(auction, thumbUrl);
+
+    TradeInfo tradeInfo = TradeInfo.of(trade.getId(), trade.getFinalPrice(), trade.getModifyDate());
+
+    ChatRoomMetaInfo meta = ChatRoomMetaInfo.of(chatRoom.getId(), auctionInfo, partnerInfo,
+        tradeInfo);
   }
 
   private boolean isVisibleTradeStatus(ChatRoom cr) {

--- a/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
@@ -99,6 +99,13 @@ public class ChatRoomService {
     Trade trade = chatRoom.getTrade();
     Auction auction = trade.getAuction();
 
+    boolean isBuyer = me.getId().equals(trade.getBuyerId());
+    boolean isSeller = me.getId().equals(trade.getSellerId());
+    if (!isBuyer && !isSeller) {
+      throw new ErrorException(ErrorCode.FORBIDDEN_CHAT_ROOM);
+    }
+
+
   }
 
   private boolean isVisibleTradeStatus(ChatRoom cr) {

--- a/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.windfall.api.chat.service;
 
 import com.windfall.api.chat.dto.request.enums.ChatRoomScope;
+import com.windfall.api.chat.dto.response.ChatRoomDetailResponse;
 import com.windfall.api.chat.dto.response.ChatRoomListResponse;
 import com.windfall.api.chat.dto.response.info.AuctionInfo;
 import com.windfall.api.chat.dto.response.info.LastMessageInfo;
@@ -83,6 +84,13 @@ public class ChatRoomService {
     return visibleRooms.stream()
         .map(cr -> toResponse(me.getId(), cr, unreadMap, buyerUserMap, auctionThumbMap))
         .toList();
+  }
+
+  public ChatRoomDetailResponse getChatRoomDetail(Long userId, Long chatRoomId, Long cursor,
+      int size) {
+
+    User me = userService.getUserById(userId);
+
   }
 
   private boolean isVisibleTradeStatus(ChatRoom cr) {

--- a/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
@@ -109,6 +109,13 @@ public class ChatRoomService {
       throw new ErrorException(ErrorCode.INVALID_TRADE_STATUS_FOR_CHAT);
     }
 
+    Long partnerId = isBuyer ? trade.getSellerId() : trade.getBuyerId();
+    User partnerUser = partnerId.equals(trade.getSellerId())
+        ? auction.getSeller() : userService.getUserById(partnerId);
+
+    PartnerInfo partnerInfo = PartnerInfo.from(partnerUser);
+
+
   }
 
   private boolean isVisibleTradeStatus(ChatRoom cr) {

--- a/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatRoomService.java
@@ -105,6 +105,9 @@ public class ChatRoomService {
       throw new ErrorException(ErrorCode.FORBIDDEN_CHAT_ROOM);
     }
 
+    if (!isVisibleTradeStatus(chatRoom)) {
+      throw new ErrorException(ErrorCode.INVALID_TRADE_STATUS_FOR_CHAT);
+    }
 
   }
 

--- a/src/main/java/com/windfall/domain/auction/repository/AuctionImageRepository.java
+++ b/src/main/java/com/windfall/domain/auction/repository/AuctionImageRepository.java
@@ -2,6 +2,7 @@ package com.windfall.domain.auction.repository;
 
 import com.windfall.domain.auction.entity.AuctionImage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +21,6 @@ public interface AuctionImageRepository extends JpaRepository<AuctionImage, Long
       )
       """)
   List<AuctionImage> findFirstImagesByAuctionIds(@Param("auctionIds") List<Long> auctionIds);
+
+  Optional<AuctionImage> findTop1ByAuctionIdOrderByIdAsc(Long auctionId);
 }

--- a/src/main/java/com/windfall/domain/chat/repository/ChatImageRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatImageRepository.java
@@ -1,8 +1,18 @@
 package com.windfall.domain.chat.repository;
 
 import com.windfall.domain.chat.entity.ChatImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatImageRepository extends JpaRepository<ChatImage, Long> {
 
+  @Query("""
+      select ci
+      from ChatImage ci
+      join fetch ci.chatMessage cm
+      where cm.id in :messageIds
+      """)
+  List<ChatImage> findByMessageIds(@Param("messageIds") List<Long> messageIds);
 }

--- a/src/main/java/com/windfall/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatMessageRepository.java
@@ -2,6 +2,7 @@ package com.windfall.domain.chat.repository;
 
 import com.windfall.domain.chat.entity.ChatMessage;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,6 +26,29 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
   List<UnreadCountProjection> countUnreadByChatRoomIds(
       @Param("userId") Long userId,
       @Param("chatRoomIds") List<Long> chatRoomIds
+  );
+
+  @Query("""
+      select cm
+      from ChatMessage cm
+      join fetch cm.sender s
+      where cm.chatRoom.id = :chatRoomId
+      order by cm.id desc
+      """)
+  List<ChatMessage> findLatest(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
+
+  @Query("""
+      select cm
+      from ChatMessage cm
+      join fetch cm.sender s
+      where cm.chatRoom.id = :chatRoomId
+        and cm.id < :cursor
+      order by cm.id desc
+      """)
+  List<ChatMessage> findOlderThan(
+      @Param("chatRoomId") Long chatRoomId,
+      @Param("cursor") Long cursor,
+      Pageable pageable
   );
 
   ChatMessage findTopByChatRoomIdOrderByCreateDateDesc(Long chatRoomId);

--- a/src/main/java/com/windfall/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatRoomRepository.java
@@ -1,6 +1,5 @@
 package com.windfall.domain.chat.repository;
 
-import com.windfall.api.chat.dto.request.enums.ChatRoomScope;
 import com.windfall.domain.chat.entity.ChatRoom;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,14 +15,14 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
       join fetch t.auction a
       join fetch a.seller s
       where (
-        (:scope = com.windfall.api.chat.dto.request.enums.ChatRoomScope.ALL and (t.buyerId = :userId or t.sellerId = :userId))
-        or (:scope = com.windfall.api.chat.dto.request.enums.ChatRoomScope.BUY and t.buyerId = :userId)
-        or (:scope = com.windfall.api.chat.dto.request.enums.ChatRoomScope.SELL and t.sellerId = :userId)
+        (:scope = 'ALL' and (t.buyerId = :userId or t.sellerId = :userId))
+        or (:scope = 'BUY' and t.buyerId = :userId)
+        or (:scope = 'SELL' and t.sellerId = :userId)
       )
       order by coalesce(cr.lastMessageAt, cr.createDate) desc
       """)
   List<ChatRoom> findChatRoomForList(
       @Param("userId") Long userId,
-      @Param("scope") ChatRoomScope scope
+      @Param("scope") String scope
   );
 }

--- a/src/main/java/com/windfall/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,7 @@ package com.windfall.domain.chat.repository;
 
 import com.windfall.domain.chat.entity.ChatRoom;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +26,15 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
       @Param("userId") Long userId,
       @Param("scope") String scope
   );
+
+  @Query("""
+      select cr
+      from ChatRoom cr
+      join fetch cr.trade t
+      join fetch t.auction a
+      join fetch a.seller s
+      where cr.id = :chatRoomId
+      """)
+  Optional<ChatRoom> findDetailById(@Param("chatRoomId") Long chatRoomId);
+
 }

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
   INVALID_S3_UPLOAD(HttpStatus.BAD_GATEWAY,"S3 이미지 업로드 실패했습니다."),
   INVALID_IMAGE_STATUS(HttpStatus.BAD_REQUEST, "경매에 연결할 수 없는 이미지 상태입니다."),
 
+  // 채팅
+  NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
 
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
   // 채팅
   NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
+  FORBIDDEN_CHAT_ROOM(HttpStatus.FORBIDDEN, "채팅방에 접근할 수 있는 권한이 없습니다."),
 
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
   // 채팅
   NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
   FORBIDDEN_CHAT_ROOM(HttpStatus.FORBIDDEN, "채팅방에 접근할 수 있는 권한이 없습니다."),
+  INVALID_TRADE_STATUS_FOR_CHAT(HttpStatus.BAD_REQUEST, "현재 거래 상태에서는 채팅을 조회할 수 없습니다."),
 
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")

--- a/src/main/java/com/windfall/global/response/CursorResponse.java
+++ b/src/main/java/com/windfall/global/response/CursorResponse.java
@@ -1,0 +1,18 @@
+package com.windfall.global.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CursorResponse<T>(
+    List<T> content,
+    Long nextCursor,
+    boolean hasNext,
+    int size,
+    LocalDateTime timeStamp
+
+
+) {
+  public static <T> CursorResponse<T> of(List<T> content, Long nextCursor, boolean hasNext, int size) {
+    return new CursorResponse<>(content, nextCursor, hasNext, size, LocalDateTime.now());
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #102 

## 📝 변경 사항
### AS-IS
* 채팅방 목록 조회 API만 존재하여, 채팅방 상세 화면 진입 시 필요한 정보(상단 메타/메시지 목록)를 조회할 수 없었음

### TO-BE

* 채팅방 상세조회 API 추가

  * 상단 메타 정보(상대방/경매/거래) + 메시지 목록을 한 번에 반환
* 메시지 목록은 커서 기반 페이징으로 제공

  * cursor 미전달 시 최신 메시지부터 size개 조회
  * nextCursor/hasNext 제공으로 과거 메시지 추가 조회 가능
* 참여자 검증 및 거래 상태 검증 로직 추가
* IMAGE 타입 메시지에 대해 ChatImage를 메시지 ID 기준으로 일괄 조회하여 메시지별 imageUrls 매핑

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 정상적인 상황
<img width="752" height="974" alt="image" src="https://github.com/user-attachments/assets/d77d1061-8ab0-4123-a0c3-a1988d88e4f8" />
<img width="648" height="939" alt="image" src="https://github.com/user-attachments/assets/638cbb03-0e8f-49d4-8372-dade2eff123b" />

- 존재하지 않는 채팅방
<img width="586" height="343" alt="image" src="https://github.com/user-attachments/assets/8dc01cda-457b-4c8f-8375-a93915252f56" />

- 접근 권한이 없는 채팅방(현재 로그인한 사용자가 구매자, 판매자가 아닌 채팅방에 접근할 경우)
<img width="580" height="383" alt="image" src="https://github.com/user-attachments/assets/e8fd2b32-f930-45d9-ab79-47b4de4869a9" />

- 접근하려는 채팅방의 거래 상태가 거래완료, 구매확정이 아닌경우
<img width="577" height="362" alt="image" src="https://github.com/user-attachments/assets/2d1dcdf9-cb96-4bbe-ad78-bc9f9bdefacf" />



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 지금 코드가 좀 지저분한데 추후 채팅방 목록 조회와 함께 리팩토링 예정입니다.
- 웹소켓 연결도 추후 pr에서 진행할 예정입니다.
