### PR TITLE
[Feature] 태그, 찜 관련 기능 추가 및 수정

### DIFF
--- a/src/main/java/com/windfall/api/auction/service/AuctionService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionService.java
@@ -130,7 +130,7 @@ public class AuctionService {
 
     tagService.deleteTag(auction);
 
-    // TODO: 찜 삭제
+    auctionLikeService.deleteLike(auction);
 
     auctionRepository.deleteById(auctionId);
   }

--- a/src/main/java/com/windfall/api/auction/service/AuctionService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionService.java
@@ -18,7 +18,6 @@ import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.auction.repository.AuctionPriceHistoryRepository;
 import com.windfall.domain.auction.repository.AuctionRepository;
-import com.windfall.domain.like.entity.AuctionLike;
 import com.windfall.domain.tag.entity.AuctionTag;
 import com.windfall.domain.tag.entity.Tag;
 import com.windfall.domain.tag.repository.AuctionTagRepository;
@@ -28,7 +27,6 @@ import com.windfall.global.exception.ErrorException;
 import com.windfall.global.response.SliceResponse;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -132,6 +130,8 @@ public class AuctionService {
 
     tagService.deleteTag(auction);
 
+    // TODO: 찜 삭제
+
     auctionRepository.deleteById(auctionId);
   }
 
@@ -230,6 +230,6 @@ public class AuctionService {
     if (userId == null) {
       return false;
     }
-    return auctionLikeService.getAuctionLike(auctionId, userId).isPresent();
+    return auctionLikeService.getActiveLike(auctionId, userId).isPresent();
   }
 }

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
@@ -2,8 +2,11 @@ package com.windfall.api.like.controller;
 
 import com.windfall.api.like.dto.response.AuctionLikeResponse;
 import com.windfall.api.like.service.AuctionLikeService;
+import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,9 +24,9 @@ public class AuctionLikeController implements AuctionLikeSpecification{
   @PostMapping("/{auctionId}/like")
   public ApiResponse<AuctionLikeResponse> toggleLike(
       @PathVariable Long auctionId,
-      @RequestParam Long userId // 제거 예정
+      @AuthenticationPrincipal CustomUserDetails user // 제거 예정
   ) {
-    AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
+    AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, user.getUserId());
     return ApiResponse.ok("찜 토글을 성공했습니다.", response);
   }
 }

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
@@ -6,17 +6,15 @@ import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auctions")
-public class AuctionLikeController implements AuctionLikeSpecification{
+public class AuctionLikeController implements AuctionLikeSpecification {
 
   private final AuctionLikeService auctionLikeService;
 
@@ -24,7 +22,7 @@ public class AuctionLikeController implements AuctionLikeSpecification{
   @PostMapping("/{auctionId}/like")
   public ApiResponse<AuctionLikeResponse> toggleLike(
       @PathVariable Long auctionId,
-      @AuthenticationPrincipal CustomUserDetails user // 제거 예정
+      @AuthenticationPrincipal CustomUserDetails user
   ) {
     AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, user.getUserId());
     return ApiResponse.ok("찜 토글을 성공했습니다.", response);

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
@@ -22,7 +22,7 @@ public interface AuctionLikeSpecification {
       @Parameter(description = "경매 ID", required = true, example = "1")
       @PathVariable Long auctionId,
 
-      @Parameter(description = "사용자 ID", required = true, example = "1")
+      @Parameter(description = "사용자 ID")
       @AuthenticationPrincipal CustomUserDetails userId
   );
 }

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Auction Like", description = "경매 찜 API")
 public interface AuctionLikeSpecification {

--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeSpecification.java
@@ -3,11 +3,13 @@ package com.windfall.api.like.controller;
 import static com.windfall.global.exception.ErrorCode.NOT_FOUND_AUCTION;
 
 import com.windfall.api.like.dto.response.AuctionLikeResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.config.swagger.ApiErrorCodes;
 import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -20,7 +22,7 @@ public interface AuctionLikeSpecification {
       @Parameter(description = "경매 ID", required = true, example = "1")
       @PathVariable Long auctionId,
 
-      @Parameter(description = "로그인 구현 후, 제거 예정", required = true, example = "1")
-      @RequestParam Long userId
+      @Parameter(description = "사용자 ID", required = true, example = "1")
+      @AuthenticationPrincipal CustomUserDetails userId
   );
 }

--- a/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
+++ b/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
@@ -65,4 +65,10 @@ public class AuctionLikeService {
   public long getLikeCount(Long auctionId) {
     return auctionLikeRepository.countByAuctionIdAndActivatedTrue(auctionId);
   }
+
+  @Transactional
+  public void deleteLike(Auction auction) {
+    auctionLikeRepository.findAllByAuction(auction)
+        .forEach(like -> auctionLikeRepository.deactivate(like.getId()));
+  }
 }

--- a/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
+++ b/src/main/java/com/windfall/api/like/service/AuctionLikeService.java
@@ -23,13 +23,20 @@ public class AuctionLikeService {
   public AuctionLikeResponse toggleLike(Long auctionId, Long userId) {
     Auction auction = getAuction(auctionId);
 
-    Optional<AuctionLike> existingLike = getAuctionLike(auctionId, userId);
+    Optional<AuctionLike> existingLike = getLike(auctionId, userId);
 
     boolean isLiked;
 
     if (existingLike.isPresent()) {
-      auctionLikeRepository.delete(existingLike.get());
-      isLiked = false;
+      AuctionLike like = existingLike.get();
+
+      if (like.isActivated()) {
+        auctionLikeRepository.deactivate(like.getId());
+        isLiked = false;
+      } else {
+        auctionLikeRepository.activate(like.getId());
+        isLiked = true;
+      }
     } else {
       auctionLikeRepository.save(AuctionLike.create(auction, userId));
       isLiked = true;
@@ -45,13 +52,17 @@ public class AuctionLikeService {
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
   }
 
-  @Transactional(readOnly = true)
-  public Optional<AuctionLike> getAuctionLike(Long auctionId, Long userId) {
+  private Optional<AuctionLike> getLike(Long auctionId, Long userId) {
     return auctionLikeRepository.findByAuctionIdAndUserId(auctionId, userId);
   }
 
   @Transactional(readOnly = true)
+  public Optional<AuctionLike> getActiveLike(Long auctionId, Long userId) {
+    return auctionLikeRepository.findActiveLike(auctionId, userId);
+  }
+
+  @Transactional(readOnly = true)
   public long getLikeCount(Long auctionId) {
-    return auctionLikeRepository.countByAuctionId(auctionId);
+    return auctionLikeRepository.countByAuctionIdAndActivatedTrue(auctionId);
   }
 }

--- a/src/main/java/com/windfall/api/tag/dto/response/SearchTagInfo.java
+++ b/src/main/java/com/windfall/api/tag/dto/response/SearchTagInfo.java
@@ -1,6 +1,7 @@
 package com.windfall.api.tag.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "태그 자동 완성 관련 응답 DTO")
 public record SearchTagInfo(
@@ -12,6 +13,6 @@ public record SearchTagInfo(
     Long tagId,
 
     @Schema(description = "경매 ID")
-    Long auctionId
+    List<Long> auctionIds
 ) {
 }

--- a/src/main/java/com/windfall/api/tag/dto/response/SearchTagInfo.java
+++ b/src/main/java/com/windfall/api/tag/dto/response/SearchTagInfo.java
@@ -1,0 +1,17 @@
+package com.windfall.api.tag.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "태그 자동 완성 관련 응답 DTO")
+public record SearchTagInfo(
+
+    @Schema(description = "태그 이름")
+    String tagName,
+
+    @Schema(description = "태그 ID")
+    Long tagId,
+
+    @Schema(description = "경매 ID")
+    Long auctionId
+) {
+}

--- a/src/main/java/com/windfall/api/tag/dto/response/SearchTagResponse.java
+++ b/src/main/java/com/windfall/api/tag/dto/response/SearchTagResponse.java
@@ -7,11 +7,11 @@ import java.util.List;
 public record SearchTagResponse (
 
     @Schema(description = "태그 자동 완성")
-    List<String> tags
+    List<SearchTagInfo> tags
 ){
 
-  public static SearchTagResponse from(List<String> tags) {
-      return new SearchTagResponse(tags);
+  public static SearchTagResponse from(List<SearchTagInfo> tags) {
+    return new SearchTagResponse(tags);
   }
 
   public static SearchTagResponse empty() {

--- a/src/main/java/com/windfall/api/tag/service/TagService.java
+++ b/src/main/java/com/windfall/api/tag/service/TagService.java
@@ -1,6 +1,7 @@
 package com.windfall.api.tag.service;
 
 import com.windfall.api.auction.dto.request.TagInfo;
+import com.windfall.api.tag.dto.response.SearchTagInfo;
 import com.windfall.api.tag.dto.response.SearchTagResponse;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.tag.entity.AuctionTag;
@@ -52,10 +53,14 @@ public class TagService {
     }
     String trimmedKeyword = request.trim();
 
-    List<String> tags = tagRepository
+    List<SearchTagInfo> tags = auctionTagRepository
         .findByKeyword(trimmedKeyword, PageRequest.of(0, 5))
         .stream()
-        .map(Tag::getTagName)
+        .map(at -> new SearchTagInfo(
+            at.getTag().getTagName(),
+            at.getTag().getId(),
+            at.getAuction().getId()
+        ))
         .toList();
 
     return SearchTagResponse.from(tags);

--- a/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
+++ b/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
@@ -1,6 +1,8 @@
 package com.windfall.domain.like.repository;
 
+import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.like.entity.AuctionLike;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -40,4 +42,6 @@ public interface AuctionLikeRepository extends JpaRepository<AuctionLike, Long> 
           where al.id = :id
       """)
   void activate(@Param("id") Long id);
+
+  List<AuctionLike> findAllByAuction(Auction auction);
 }

--- a/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
+++ b/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
@@ -1,13 +1,43 @@
 package com.windfall.domain.like.repository;
 
-import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.like.entity.AuctionLike;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AuctionLikeRepository extends JpaRepository<AuctionLike, Long> {
 
   Optional<AuctionLike> findByAuctionIdAndUserId(Long auctionId, Long userId);
 
-  long countByAuctionId(Long auctionId);
+  @Query("""
+        select al
+        from AuctionLike al
+        where al.auction.id = :auctionId
+          and al.userId = :userId
+          and al.activated = true
+      """)
+  Optional<AuctionLike> findActiveLike(
+      @Param("auctionId") Long auctionId,
+      @Param("userId") Long userId
+  );
+
+  long countByAuctionIdAndActivatedTrue(Long auctionId);
+
+  @Modifying
+  @Query("""
+          update AuctionLike al
+          set al.activated = false
+          where al.id = :id
+      """)
+  void deactivate(@Param("id") Long id);
+
+  @Modifying
+  @Query("""
+          update AuctionLike al
+          set al.activated = true
+          where al.id = :id
+      """)
+  void activate(@Param("id") Long id);
 }

--- a/src/main/java/com/windfall/domain/tag/entity/AuctionTag.java
+++ b/src/main/java/com/windfall/domain/tag/entity/AuctionTag.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuctionTag extends BaseEntity {
 

--- a/src/main/java/com/windfall/domain/tag/repository/AuctionTagRepository.java
+++ b/src/main/java/com/windfall/domain/tag/repository/AuctionTagRepository.java
@@ -4,7 +4,6 @@ import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.tag.entity.AuctionTag;
 import com.windfall.domain.tag.entity.Tag;
 import java.util.List;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,10 +15,10 @@ public interface AuctionTagRepository extends JpaRepository<AuctionTag, Long> {
   boolean existsByTag(Tag tag);
 
   @Query("""
-    select at
-    from AuctionTag at
-    join fetch at.tag t
-    where t.tagName like concat('%', :keyword, '%')
-""")
-  List<AuctionTag> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+          select at
+          from AuctionTag at
+          join fetch at.tag t
+          where t.tagName like concat('%', :keyword, '%')
+      """)
+  List<AuctionTag> findByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/windfall/domain/tag/repository/AuctionTagRepository.java
+++ b/src/main/java/com/windfall/domain/tag/repository/AuctionTagRepository.java
@@ -4,11 +4,22 @@ import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.tag.entity.AuctionTag;
 import com.windfall.domain.tag.entity.Tag;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AuctionTagRepository extends JpaRepository<AuctionTag, Long> {
 
   List<AuctionTag> findAllByAuction(Auction auction);
 
   boolean existsByTag(Tag tag);
+
+  @Query("""
+    select at
+    from AuctionTag at
+    join fetch at.tag t
+    where t.tagName like concat('%', :keyword, '%')
+""")
+  List<AuctionTag> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/windfall/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/windfall/domain/tag/repository/TagRepository.java
@@ -1,22 +1,10 @@
 package com.windfall.domain.tag.repository;
 
 import com.windfall.domain.tag.entity.Tag;
-import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
   Optional<Tag> findByTagName(String tagName);
-
-  @Query("""
-          SELECT t
-          FROM Tag t
-          WHERE t.tagName LIKE CONCAT(:keyword, '%')
-          ORDER BY t.tagName ASC
-      """)
-  List<Tag> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
+++ b/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
@@ -2,6 +2,7 @@ package com.windfall.api.like;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -23,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionLikeServiceTest {
@@ -50,14 +50,16 @@ class AuctionLikeServiceTest {
     when(auctionRepository.findById(auctionId)).thenReturn(Optional.of(auction));
     when(auctionLikeRepository.findByAuctionIdAndUserId(auctionId, userId)).thenReturn(
         Optional.empty());
-    when(auctionLikeRepository.countByAuctionId(auctionId)).thenReturn(1L);
+    when(auctionLikeRepository.countByAuctionIdAndActivatedTrue(auctionId)).thenReturn(1L);
 
     // when
     AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
 
     // then
     verify(auctionLikeRepository, times(1)).save(any(AuctionLike.class));
-    verify(auctionLikeRepository, never()).delete(any());
+    verify(auctionLikeRepository, never()).deactivate(anyLong());
+    verify(auctionLikeRepository, never()).activate(anyLong());
+
     assertThat(response.isLiked()).isTrue();
     assertThat(response.likeCount()).isEqualTo(1L);
   }
@@ -70,14 +72,16 @@ class AuctionLikeServiceTest {
     when(auctionRepository.findById(auctionId)).thenReturn(Optional.of(auction));
     when(auctionLikeRepository.findByAuctionIdAndUserId(auctionId, userId)).thenReturn(
         Optional.of(existingLike));
-    when(auctionLikeRepository.countByAuctionId(auctionId)).thenReturn(0L);
+    when(auctionLikeRepository.countByAuctionIdAndActivatedTrue(auctionId)).thenReturn(0L);
 
     // when
     AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, userId);
 
     // then
-    verify(auctionLikeRepository, times(1)).delete(existingLike);
+    verify(auctionLikeRepository, times(1)).deactivate(existingLike.getId());
     verify(auctionLikeRepository, never()).save(any());
+    verify(auctionLikeRepository, never()).activate(anyLong());
+
     assertThat(response.isLiked()).isFalse();
     assertThat(response.likeCount()).isEqualTo(0L);
   }

--- a/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
+++ b/src/test/java/com/windfall/api/like/AuctionLikeServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -17,6 +18,7 @@ import com.windfall.domain.like.entity.AuctionLike;
 import com.windfall.domain.like.repository.AuctionLikeRepository;
 import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -102,5 +104,25 @@ class AuctionLikeServiceTest {
 
     verify(auctionLikeRepository, never()).save(any());
     verify(auctionLikeRepository, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("[경매찜 삭제1] 경매 찜을 삭제하는 경우(소프트 딜리트)")
+  void delete1() {
+    // given
+    AuctionLike like1 = mock(AuctionLike.class);
+    AuctionLike like2 = mock(AuctionLike.class);
+
+    when(auctionLikeRepository.findAllByAuction(auction)).thenReturn(List.of(like1, like2));
+
+    when(like1.getId()).thenReturn(1L);
+    when(like2.getId()).thenReturn(2L);
+
+    // when
+    auctionLikeService.deleteLike(auction);
+
+    // then
+    verify(auctionLikeRepository, times(1)).deactivate(1L);
+    verify(auctionLikeRepository, times(1)).deactivate(2L);
   }
 }

--- a/src/test/java/com/windfall/api/tag/TagServiceTest.java
+++ b/src/test/java/com/windfall/api/tag/TagServiceTest.java
@@ -3,6 +3,7 @@ package com.windfall.api.tag;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.windfall.api.auction.dto.request.TagInfo;
+import com.windfall.api.tag.dto.response.SearchTagInfo;
 import com.windfall.api.tag.dto.response.SearchTagResponse;
 import com.windfall.api.tag.service.TagService;
 import com.windfall.domain.auction.entity.Auction;
@@ -133,12 +134,19 @@ class TagServiceTest {
   @DisplayName("[태그 검색1] DB에 저장된 태그가 5개 이상일 때, 태그 자동완성을 응답하는 경우")
   void searchTag1() {
     // given: DB에 태그 데이터 저장
-    tagRepository.save(Tag.create("나무"));
-    tagRepository.save(Tag.create("나비"));
-    tagRepository.save(Tag.create("나이키"));
-    tagRepository.save(Tag.create("나이키에어"));
-    tagRepository.save(Tag.create("나이키운동화"));
-    tagRepository.save(Tag.create("나침반")); // 6번째
+    Tag tag1 = tagRepository.save(Tag.create("나무"));
+    Tag tag2 = tagRepository.save(Tag.create("나비"));
+    Tag tag3 = tagRepository.save(Tag.create("나이키"));
+    Tag tag4 = tagRepository.save(Tag.create("나이키에어"));
+    Tag tag5 = tagRepository.save(Tag.create("나이키운동화"));
+    Tag tag6 = tagRepository.save(Tag.create("나침반"));
+
+    auctionTagRepository.save(AuctionTag.create(auction1, tag1));
+    auctionTagRepository.save(AuctionTag.create(auction1, tag2));
+    auctionTagRepository.save(AuctionTag.create(auction1, tag3));
+    auctionTagRepository.save(AuctionTag.create(auction1, tag4));
+    auctionTagRepository.save(AuctionTag.create(auction1, tag5));
+    auctionTagRepository.save(AuctionTag.create(auction1, tag6));
 
     String request = "나";
 
@@ -147,18 +155,30 @@ class TagServiceTest {
 
     // then: 최대 5개만 반환 확인
     assertEquals(5, response.tags().size());
-    assertEquals(List.of("나무", "나비", "나이키", "나이키에어", "나이키운동화"),
-        response.tags());
+
+    List<String> tagNames = response.tags().stream()
+        .map(SearchTagInfo::tagName)
+        .toList();
+
+    assertEquals(
+        List.of("나무", "나비", "나이키", "나이키에어", "나이키운동화"),
+        tagNames
+    );
   }
 
   @Test
   @DisplayName("[태그 검색2] 태그 검색어로 앞, 뒤 공백을 넣는 경우")
   void searchTag2() {
     // given: DB에 태그 데이터 저장
-    tagRepository.save(Tag.create("나무"));
-    tagRepository.save(Tag.create("나비"));
-    tagRepository.save(Tag.create("나이키"));
-    tagRepository.save(Tag.create("나이키에어"));
+    Tag tag1 = tagRepository.save(Tag.create("나무"));
+    Tag tag2 = tagRepository.save(Tag.create("나비"));
+    Tag tag3 = tagRepository.save(Tag.create("나이키"));
+    Tag tag4 = tagRepository.save(Tag.create("나이키에어"));
+
+    auctionTagRepository.save(AuctionTag.create(auction1, tag1));
+    auctionTagRepository.save(AuctionTag.create(auction1, tag2));
+    auctionTagRepository.save(AuctionTag.create(auction1, tag3));
+    auctionTagRepository.save(AuctionTag.create(auction1, tag4));
 
     String request = " 나 ";
 
@@ -167,7 +187,13 @@ class TagServiceTest {
 
     // then
     assertEquals(4, response.tags().size());
-    assertEquals(List.of("나무", "나비", "나이키", "나이키에어"), response.tags());
+
+    List<String> tagNames = response.tags()
+        .stream()
+        .map(SearchTagInfo::tagName)
+        .toList();
+
+    assertEquals(List.of("나무", "나비", "나이키", "나이키에어"), tagNames);
   }
 
   @Test


### PR DESCRIPTION
## 📌 관련 이슈
- close #97 

## 📝 변경 사항
### AS-IS
- 찜 컨트롤러에 유저가 연결 안 됨
- 태그 자동완성 응답에 태그id, 경매id 값 부재
- 찜 등록/해제가 on/off가 아닌 하드 딜리트 방식임
- 경매 삭제 시, 찜 삭제 로직 부재

### TO-BE
- 찜 컨트롤러에 유저 연결(@AuthenticationPrincipal)
- 태그 자동완성 응답에 태그id, 경매id 값 추가
- 전에 논의한 대로 찜 등록/해제를 on/off로 변경
- 경매 삭제 시, 찜 삭제 로직 추가(소프트 딜리트) + 테스트 코드 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트- 스웨거
- [x] 로컬 테스트

## 📸 스크린샷
<img width="490" height="540" alt="image" src="https://github.com/user-attachments/assets/0a49a981-4394-47d2-b074-69be598da0b2" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- @myoungjinseo 님 미리 말씀 드리긴 했지만, 태그 응답 값 추가한 거 확인 부탁드립니다!
- 전에 논의했을 때 찜을 activated로 on/off하기로 했는데 제가 실수로 다르게 해서 수정했습니다.
- 이거 merge 후, 죄송하지만 알림 세팅 늦어도 30일까지 꼭 완료하도록 하겠습니다..!!!