### PR TITLE
[Feature] 채팅방 메시지 읽음 처리 API 추가 및 권한 검증/벌크 업데이트 적용

### DIFF
--- a/src/main/java/com/windfall/api/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatMessageController.java
@@ -1,0 +1,31 @@
+package com.windfall.api.chat.controller;
+
+import com.windfall.api.chat.dto.response.ChatReadMarkResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat-rooms")
+public class ChatMessageController implements ChatMessageControllerSpecification {
+
+  private final ChatMessageReadService chatMessageReadService;
+
+  @Override
+  @PatchMapping("/{chatRoomId}/messages/read")
+  public ApiResponse<ChatReadMarkResponse> markChatMessagesAsRead(
+      @PathVariable Long chatRoomId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    Long userId = userDetails.getUserId();
+    ChatReadMarkResponse response = chatMessageReadService.markAsRead(chatRoomId, userId);
+    return ApiResponse.ok(response);
+  }
+}
+

--- a/src/main/java/com/windfall/api/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatMessageController.java
@@ -1,6 +1,7 @@
 package com.windfall.api.chat.controller;
 
 import com.windfall.api.chat.dto.response.ChatReadMarkResponse;
+import com.windfall.api.chat.service.ChatMessageService;
 import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/chat-rooms")
 public class ChatMessageController implements ChatMessageControllerSpecification {
 
-  private final ChatMessageReadService chatMessageReadService;
+  private final ChatMessageService chatMessageService;
 
   @Override
   @PatchMapping("/{chatRoomId}/messages/read")
@@ -24,7 +25,7 @@ public class ChatMessageController implements ChatMessageControllerSpecification
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
     Long userId = userDetails.getUserId();
-    ChatReadMarkResponse response = chatMessageReadService.markAsRead(chatRoomId, userId);
+    ChatReadMarkResponse response = chatMessageService.markAsRead(chatRoomId, userId);
     return ApiResponse.ok(response);
   }
 }

--- a/src/main/java/com/windfall/api/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatMessageController.java
@@ -26,7 +26,7 @@ public class ChatMessageController implements ChatMessageControllerSpecification
   ) {
     Long userId = userDetails.getUserId();
     ChatReadMarkResponse response = chatMessageService.markAsRead(chatRoomId, userId);
-    return ApiResponse.ok(response);
+    return ApiResponse.ok("채팅방의 읽지 않은 메시지가 모두 읽음 처리되었습니다.", response);
   }
 }
 

--- a/src/main/java/com/windfall/api/chat/controller/ChatMessageControllerSpecification.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatMessageControllerSpecification.java
@@ -1,0 +1,26 @@
+package com.windfall.api.chat.controller;
+
+import com.windfall.api.chat.dto.response.ChatReadMarkResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "ChatMessage", description = "채팅 메시지 API")
+public interface ChatMessageControllerSpecification {
+
+  @Operation(
+      summary = "채팅 메시지 읽음 처리",
+      description = "채팅방에 들어갈 때 호출. 해당 채팅방에서 '내가 보낸 메시지'를 제외한, 읽지 않은 메시지(isRead=false)를 모두 읽음 처리합니다."
+  )
+  ApiResponse<ChatReadMarkResponse> markChatMessagesAsRead(
+      @Parameter(description = "채팅방 ID", example = "1")
+      @PathVariable Long chatRoomId,
+
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  );
+}
+

--- a/src/main/java/com/windfall/api/chat/dto/response/ChatReadMarkResponse.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/ChatReadMarkResponse.java
@@ -1,0 +1,10 @@
+package com.windfall.api.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅 읽음 처리 응답 DTO")
+public record ChatReadMarkResponse(
+
+    @Schema(description = "업데이트된 읽지 않은 메시지 수")
+    int updateCount
+) {}

--- a/src/main/java/com/windfall/api/chat/dto/response/ChatReadMarkResponse.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/ChatReadMarkResponse.java
@@ -7,4 +7,8 @@ public record ChatReadMarkResponse(
 
     @Schema(description = "업데이트된 읽지 않은 메시지 수")
     int updateCount
-) {}
+) {
+    public static ChatReadMarkResponse of(int updatedCount) {
+        return new ChatReadMarkResponse(updatedCount);
+    }
+}

--- a/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
@@ -30,6 +30,9 @@ public class ChatMessageService {
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_CHAT_ROOM));
 
     validateParticipant(chatRoom, userId);
+
+    int updated = chatMessageRepository.markAllAsReadExcludingSender(chatRoomId, userId);
+    return new ChatReadMarkResponse(updated);
   }
 
   private void validateParticipant(ChatRoom chatRoom, Long userId) {

--- a/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
@@ -30,7 +30,7 @@ public class ChatMessageService {
     validateParticipant(chatRoom.getTrade(), userId);
 
     int updated = chatMessageRepository.markAllAsReadExcludingSender(chatRoomId, userId);
-    return new ChatReadMarkResponse(updated);
+    return ChatReadMarkResponse.of(updated);
   }
 
   private ChatRoom getChatRoomWithTrade(Long chatRoomId) {

--- a/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
@@ -27,7 +27,7 @@ public class ChatMessageService {
 
     ChatRoom chatRoom = getChatRoomWithTrade(chatRoomId);
 
-    validateParticipant(chatRoom, userId);
+    validateParticipant(chatRoom.getTrade(), userId);
 
     int updated = chatMessageRepository.markAllAsReadExcludingSender(chatRoomId, userId);
     return new ChatReadMarkResponse(updated);
@@ -38,13 +38,9 @@ public class ChatMessageService {
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_CHAT_ROOM));
   }
 
-  private void validateParticipant(ChatRoom chatRoom, Long userId) {
-    Trade trade = chatRoom.getTrade();
-    boolean isParticipant = userId.equals(trade.getBuyerId()) || userId.equals(trade.getSellerId());
-
-    if (!isParticipant) {
+  private void validateParticipant(Trade trade, Long userId) {
+    if (!userId.equals(trade.getBuyerId()) && !userId.equals(trade.getSellerId())) {
       throw new ErrorException(ErrorCode.FORBIDDEN_CHAT_ROOM);
     }
   }
-
 }

--- a/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
@@ -5,6 +5,7 @@ import com.windfall.api.user.service.UserService;
 import com.windfall.domain.chat.entity.ChatRoom;
 import com.windfall.domain.chat.repository.ChatMessageRepository;
 import com.windfall.domain.chat.repository.ChatRoomRepository;
+import com.windfall.domain.trade.entity.Trade;
 import com.windfall.domain.user.entity.User;
 import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
@@ -28,6 +29,16 @@ public class ChatMessageService {
     ChatRoom chatRoom = chatRoomRepository.findByIdWithTrade(chatRoomId)
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_CHAT_ROOM));
 
+    validateParticipant(chatRoom, userId);
+  }
+
+  private void validateParticipant(ChatRoom chatRoom, Long userId) {
+    Trade trade = chatRoom.getTrade();
+    boolean isParticipant = userId.equals(trade.getBuyerId()) || userId.equals(trade.getSellerId());
+
+    if (!isParticipant) {
+      throw new ErrorException(ErrorCode.FORBIDDEN_CHAT_ROOM);
+    }
   }
 
 }

--- a/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
@@ -1,9 +1,16 @@
 package com.windfall.api.chat.service;
 
+import com.windfall.api.chat.dto.response.ChatReadMarkResponse;
+import com.windfall.api.user.service.UserService;
+import com.windfall.domain.chat.entity.ChatRoom;
 import com.windfall.domain.chat.repository.ChatMessageRepository;
 import com.windfall.domain.chat.repository.ChatRoomRepository;
+import com.windfall.domain.user.entity.User;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,5 +18,16 @@ public class ChatMessageService {
 
   private final ChatRoomRepository chatRoomRepository;
   private final ChatMessageRepository chatMessageRepository;
+  private final UserService userService;
+
+  @Transactional
+  public ChatReadMarkResponse markAsRead(Long chatRoomId, Long userId) {
+
+    User me = userService.getUserById(userId);
+
+    ChatRoom chatRoom = chatRoomRepository.findByIdWithTrade(chatRoomId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+
+  }
 
 }

--- a/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
@@ -6,7 +6,6 @@ import com.windfall.domain.chat.entity.ChatRoom;
 import com.windfall.domain.chat.repository.ChatMessageRepository;
 import com.windfall.domain.chat.repository.ChatRoomRepository;
 import com.windfall.domain.trade.entity.Trade;
-import com.windfall.domain.user.entity.User;
 import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
@@ -24,15 +23,19 @@ public class ChatMessageService {
   @Transactional
   public ChatReadMarkResponse markAsRead(Long chatRoomId, Long userId) {
 
-    User me = userService.getUserById(userId);
+    userService.getUserById(userId);
 
-    ChatRoom chatRoom = chatRoomRepository.findByIdWithTrade(chatRoomId)
-        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+    ChatRoom chatRoom = getChatRoomWithTrade(chatRoomId);
 
     validateParticipant(chatRoom, userId);
 
     int updated = chatMessageRepository.markAllAsReadExcludingSender(chatRoomId, userId);
     return new ChatReadMarkResponse(updated);
+  }
+
+  private ChatRoom getChatRoomWithTrade(Long chatRoomId) {
+    return chatRoomRepository.findByIdWithTrade(chatRoomId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_CHAT_ROOM));
   }
 
   private void validateParticipant(ChatRoom chatRoom, Long userId) {

--- a/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatMessageService.java
@@ -1,0 +1,15 @@
+package com.windfall.api.chat.service;
+
+import com.windfall.domain.chat.repository.ChatMessageRepository;
+import com.windfall.domain.chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatMessageRepository chatMessageRepository;
+
+}

--- a/src/main/java/com/windfall/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatMessageRepository.java
@@ -4,6 +4,7 @@ import com.windfall.domain.chat.entity.ChatMessage;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -52,4 +53,17 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
   );
 
   ChatMessage findTopByChatRoomIdOrderByCreateDateDesc(Long chatRoomId);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("""
+      update ChatMessage m
+         set m.isRead = true
+       where m.chatRoom.id = :chatRoomId
+         and m.isRead = false
+         and m.sender.id <> :userId
+      """)
+  int markAllAsReadExcludingSender(
+      @Param("chatRoomId") Long chatRoomId,
+      @Param("userId") Long userId
+  );
 }

--- a/src/main/java/com/windfall/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatRoomRepository.java
@@ -37,4 +37,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
       """)
   Optional<ChatRoom> findDetailById(@Param("chatRoomId") Long chatRoomId);
 
+  @Query("""
+      select cr
+      from ChatRoom cr
+      join fetch cr.trade t
+      where cr.id = :chatRoomId
+      """)
+  Optional<ChatRoom> findByIdWithTrade(@Param("chatRoomId") Long chatRoomId);
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #107 

## 📝 변경 사항
### AS-IS
- 채팅 상세 조회(GET)만 존재하며, 채팅방 입장 시 읽음 처리 로직이 별도 API로 분리되지 않음
- 메시지 읽음 상태(isRead) 갱신이 명확히 정의되지 않아 미읽음 카운트 최신화가 어렵고 UX 일관성이 떨어질 수 있음

### TO-BE
- 채팅방 입장 시 호출하는 읽음 처리 API(PATCH) 신규 구현
  - `PATCH /api/v1/chat-rooms/{chatRoomId}/messages/read`
- 채팅방 참여자만 읽음 처리 가능하도록 권한 검증 추가
  - Trade의 buyerId/sellerId 기준 검증
- 벌크 업데이트로 미읽음 메시지 일괄 처리(성능/쿼리 최적화)
  - `isRead=false` 이면서 `sender != me` 인 메시지만 `true`로 변경
- Swagger ControllerSpecification 및 응답 DTO(ChatReadMarkResponse) 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 정상 상황
<img width="638" height="564" alt="image" src="https://github.com/user-attachments/assets/8fbf1e2c-fd00-465b-8259-c74b6cb97694" />

<img width="1690" height="864" alt="image" src="https://github.com/user-attachments/assets/45fcd122-5983-4cd0-bec4-03a622c55ab1" />

<img width="1694" height="814" alt="image" src="https://github.com/user-attachments/assets/304cc2b5-7357-4a4d-bbce-2da69e8315e9" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 급하게 해서 깔끔하지 않을 수도 있습니다,, 피드백 부탁드립니다!