### PR TITLE
[Feature] 알림 세팅 CRU

### DIFF
--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auctions/{auctionId}/notification-settings")
 @RequiredArgsConstructor
-public class NotificationSettingController {
+public class NotificationSettingController implements NotificationSettingSpecification {
 
   private final NotificationSettingService notificationSettingService;
 

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
@@ -1,0 +1,45 @@
+package com.windfall.api.notificationsetting.controller;
+
+import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
+import com.windfall.api.notificationsetting.dto.response.ReadNotySettingResponse;
+import com.windfall.api.notificationsetting.dto.response.UpdateNotySettingResponse;
+import com.windfall.api.notificationsetting.service.NotificationSettingService;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auctions/{auctionId}/notification-settings")
+@RequiredArgsConstructor
+public class NotificationSettingController {
+
+  private final NotificationSettingService notificationSettingService;
+
+  @GetMapping
+  public ApiResponse<ReadNotySettingResponse> read(
+      @PathVariable Long auctionId,
+      @AuthenticationPrincipal CustomUserDetails user
+  ) {
+    ReadNotySettingResponse response = notificationSettingService
+        .read(auctionId, user.getUserId());
+    return ApiResponse.ok("알림 세팅 조회를 성공했습니다.", response);
+  }
+
+  @PutMapping
+  public ApiResponse<UpdateNotySettingResponse> update(
+      @PathVariable Long auctionId,
+      @RequestBody UpdateNotySettingRequest request,
+      @AuthenticationPrincipal CustomUserDetails user
+  ) {
+    UpdateNotySettingResponse response = notificationSettingService
+        .update(auctionId, request, user.getUserId());
+    return ApiResponse.ok("알림 세팅 수정을 성공했습니다.", response);
+  }
+}

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
@@ -1,0 +1,8 @@
+package com.windfall.api.notificationsetting.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Notification Setting", description = "알림 세팅 API")
+public interface NotificationSettingSpecification {
+
+}

--- a/src/main/java/com/windfall/api/notificationsetting/dto/request/UpdateNotySettingRequest.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/request/UpdateNotySettingRequest.java
@@ -1,0 +1,17 @@
+package com.windfall.api.notificationsetting.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 세팅 수정 요청 DTO")
+public record UpdateNotySettingRequest (
+
+    @Schema(description = "경매 시작 설정 여부", example = "true")
+    boolean auctionStart,
+
+    @Schema(description = "경매 종료 설정 여부", example = "true")
+    boolean auctionEnd,
+
+    @Schema(description = "가격 도달 설정 여부", example = "true")
+    boolean priceReached
+){
+}

--- a/src/main/java/com/windfall/api/notificationsetting/dto/response/ReadNotySettingResponse.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/response/ReadNotySettingResponse.java
@@ -1,0 +1,41 @@
+package com.windfall.api.notificationsetting.dto.response;
+
+import com.windfall.domain.notification.entity.NotificationSetting;
+import com.windfall.domain.notification.enums.NotificationSettingType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Schema(description = "알림 세팅 조회 응답 DTO")
+public record ReadNotySettingResponse (
+
+    @Schema(description = "경매 시작 설정 여부")
+    boolean auctionStart,
+
+    @Schema(description = "경매 종료 설정 여부")
+    boolean auctionEnd,
+
+    @Schema(description = "가격 도달 설정 여부")
+    boolean priceReached
+){
+
+  public static ReadNotySettingResponse allDisabled() {
+    return new ReadNotySettingResponse(false, false, false);
+  }
+
+  public static ReadNotySettingResponse from(List<NotificationSetting> settings) {
+    Map<NotificationSettingType, Boolean> map =
+        settings.stream()
+            .collect(Collectors.toMap(
+                NotificationSetting::getType,
+                NotificationSetting::isActivated
+            ));
+
+    return new ReadNotySettingResponse(
+        map.getOrDefault(NotificationSettingType.AUCTION_START, false),
+        map.getOrDefault(NotificationSettingType.AUCTION_END, false),
+        map.getOrDefault(NotificationSettingType.PRICE_REACHED, false)
+    );
+  }
+}

--- a/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateNotySettingResponse.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateNotySettingResponse.java
@@ -1,0 +1,26 @@
+package com.windfall.api.notificationsetting.dto.response;
+
+import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 세팅 수정 응답 DTO")
+public record UpdateNotySettingResponse (
+
+    @Schema(description = "경매 시작 설정 여부")
+    boolean auctionStart,
+
+    @Schema(description = "경매 종료 설정 여부")
+    boolean auctionEnd,
+
+    @Schema(description = "가격 도달 설정 여부")
+    boolean priceReached
+) {
+
+  public static UpdateNotySettingResponse from(UpdateNotySettingRequest request) {
+      return new UpdateNotySettingResponse(
+          request.auctionStart(),
+          request.auctionEnd(),
+          request.priceReached()
+      );
+  }
+}

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -71,6 +71,7 @@ public class NotificationSettingService {
         );
 
     setting.updateActivated(activated);
+    notificationSettingRepository.save(setting);
   }
 
   // 알림 발송 판단용
@@ -79,6 +80,6 @@ public class NotificationSettingService {
     return notificationSettingRepository
         .findByUserIdAndAuctionIdAndType(userId, auctionId, type)
         .map(NotificationSetting::isActivated)
-        .orElse(false); // row 없으면 비활성화
+        .orElse(false); // row 없으면 비활성화 반환
   }
 }

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -1,0 +1,84 @@
+package com.windfall.api.notificationsetting.service;
+
+import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
+import com.windfall.api.notificationsetting.dto.response.ReadNotySettingResponse;
+import com.windfall.api.notificationsetting.dto.response.UpdateNotySettingResponse;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.notification.entity.NotificationSetting;
+import com.windfall.domain.notification.enums.NotificationSettingType;
+import com.windfall.domain.notification.repository.NotificationSettingRepository;
+import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.repository.UserRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+
+  private final NotificationSettingRepository notificationSettingRepository;
+  private final UserRepository userRepository;
+  private final AuctionRepository auctionRepository;
+
+  @Transactional(readOnly = true)
+  public ReadNotySettingResponse read(Long auctionId, Long userId) {
+    List<NotificationSetting> settings =
+        notificationSettingRepository.findByUserIdAndAuctionId(userId, auctionId);
+
+    // row가 하나도 없으면 전부 비활성화
+    if (settings.isEmpty()) {
+      return ReadNotySettingResponse.allDisabled();
+    }
+
+    return ReadNotySettingResponse.from(settings);
+  }
+
+  @Transactional
+  public UpdateNotySettingResponse update(Long auctionId, UpdateNotySettingRequest request,
+      Long userId
+  ) {
+    User user = getUser(userId);
+    Auction auction = getAuction(auctionId);
+
+    upsert(user, auction, NotificationSettingType.AUCTION_START, request.auctionStart());
+    upsert(user, auction, NotificationSettingType.AUCTION_END, request.auctionEnd());
+    upsert(user, auction, NotificationSettingType.PRICE_REACHED, request.priceReached());
+
+    return UpdateNotySettingResponse.from(request);
+  }
+
+  private User getUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_USER));
+  }
+
+  private Auction getAuction(Long auctionId) {
+    return auctionRepository.findById(auctionId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION));
+  }
+
+  private void upsert(User user, Auction auction, NotificationSettingType type,
+      boolean activated
+  ) {
+    NotificationSetting setting = notificationSettingRepository
+        .findByUserIdAndAuctionIdAndType(user.getId(), auction.getId(), type)
+        .orElseGet(() -> NotificationSetting.create(user, auction, type)
+        );
+
+    setting.updateActivated(activated);
+  }
+
+  // 알림 발송 판단용
+  @Transactional(readOnly = true)
+  public boolean isEnabled(Long userId, Long auctionId, NotificationSettingType type) {
+    return notificationSettingRepository
+        .findByUserIdAndAuctionIdAndType(userId, auctionId, type)
+        .map(NotificationSetting::isActivated)
+        .orElse(false); // row 없으면 비활성화
+  }
+}

--- a/src/main/java/com/windfall/domain/notification/entity/NotificationSetting.java
+++ b/src/main/java/com/windfall/domain/notification/entity/NotificationSetting.java
@@ -1,7 +1,7 @@
 package com.windfall.domain.notification.entity;
 
 import com.windfall.domain.auction.entity.Auction;
-import com.windfall.domain.notification.enums.NotificationType;
+import com.windfall.domain.notification.enums.NotificationSettingType;
 import com.windfall.domain.user.entity.User;
 import com.windfall.global.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -11,6 +11,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,6 +24,11 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(
+    uniqueConstraints = @UniqueConstraint(
+        columnNames = {"user_id", "auction_id", "type"}
+    )
+)
 public class NotificationSetting extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -34,5 +41,24 @@ public class NotificationSetting extends BaseEntity {
 
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
-  private NotificationType type;
+  private NotificationSettingType type;
+
+  public static NotificationSetting create(
+      User user,
+      Auction auction,
+      NotificationSettingType type
+  ) {
+    NotificationSetting setting = NotificationSetting.builder()
+        .user(user)
+        .auction(auction)
+        .type(type)
+        .build();
+
+    setting.updateActivated(false);
+    return setting;
+  }
+
+  public void updateActivated(boolean activated) {
+    this.setActivated(activated);
+  }
 }

--- a/src/main/java/com/windfall/domain/notification/enums/NotificationSettingType.java
+++ b/src/main/java/com/windfall/domain/notification/enums/NotificationSettingType.java
@@ -1,0 +1,15 @@
+package com.windfall.domain.notification.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationSettingType {
+
+  AUCTION_START("경매 시작"),
+  AUCTION_END("경매 종료"),
+  PRICE_REACHED("가격 도달");
+
+  private final String description;
+}

--- a/src/main/java/com/windfall/domain/notification/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/windfall/domain/notification/repository/NotificationSettingRepository.java
@@ -1,7 +1,15 @@
 package com.windfall.domain.notification.repository;
 
 import com.windfall.domain.notification.entity.NotificationSetting;
+import com.windfall.domain.notification.enums.NotificationSettingType;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NotificationSettingRepository extends JpaRepository<NotificationSetting,Long> {
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+  Optional<NotificationSetting> findByUserIdAndAuctionIdAndType(Long userId, Long auctionId,
+      NotificationSettingType type);
+
+  List<NotificationSetting> findByUserIdAndAuctionId(Long userId, Long auctionId);
 }

--- a/src/main/java/com/windfall/global/entity/BaseEntity.java
+++ b/src/main/java/com/windfall/global/entity/BaseEntity.java
@@ -32,4 +32,7 @@ public abstract class BaseEntity {
 
     private boolean activated = true; //기본값 설정
 
+    protected void setActivated(boolean activated) {
+        this.activated = activated;
+    }
 }

--- a/src/test/java/com/windfall/api/notificationsetting/NotificationSettingServiceTest.java
+++ b/src/test/java/com/windfall/api/notificationsetting/NotificationSettingServiceTest.java
@@ -1,0 +1,139 @@
+package com.windfall.api.notificationsetting;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
+import com.windfall.api.notificationsetting.dto.response.ReadNotySettingResponse;
+import com.windfall.api.notificationsetting.dto.response.UpdateNotySettingResponse;
+import com.windfall.api.notificationsetting.service.NotificationSettingService;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.notification.entity.NotificationSetting;
+import com.windfall.domain.notification.enums.NotificationSettingType;
+import com.windfall.domain.notification.repository.NotificationSettingRepository;
+import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.repository.UserRepository;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationSettingServiceTest {
+
+  @Mock
+  private NotificationSettingRepository notificationSettingRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private AuctionRepository auctionRepository;
+
+  @InjectMocks
+  private NotificationSettingService service;
+
+  @Mock
+  private User user;
+
+  @Mock
+  private Auction auction;
+
+  Long userId = 1L;
+  Long auctionId = 1L;
+
+  @Test
+  @DisplayName("[알림 세팅 조회1] 알림 세팅 수정을 한 번도 안 한 상태에서 조회하는 경우")
+  void success1() {
+    // given
+    when(notificationSettingRepository.findByUserIdAndAuctionId(userId, auctionId))
+        .thenReturn(Collections.emptyList());
+
+    // when
+    ReadNotySettingResponse response = service.read(auctionId, userId);
+
+    // then
+    assertFalse(response.auctionStart());
+    assertFalse(response.auctionEnd());
+    assertFalse(response.priceReached());
+  }
+
+  @Test
+  @DisplayName("[알림 세팅 수정1] 알림 세팅을 수정하는 경우")
+  void success2() {
+    // given
+    UpdateNotySettingRequest request = new UpdateNotySettingRequest(true, false, true);
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(auctionRepository.findById(auctionId)).thenReturn(Optional.of(auction));
+
+    when(user.getId()).thenReturn(userId);
+    when(auction.getId()).thenReturn(auctionId);
+
+    when(notificationSettingRepository.findByUserIdAndAuctionIdAndType(userId, auctionId,
+        NotificationSettingType.AUCTION_START))
+        .thenReturn(Optional.empty());
+    when(notificationSettingRepository.findByUserIdAndAuctionIdAndType(userId, auctionId,
+        NotificationSettingType.AUCTION_END))
+        .thenReturn(Optional.empty());
+    when(notificationSettingRepository.findByUserIdAndAuctionIdAndType(userId, auctionId,
+        NotificationSettingType.PRICE_REACHED))
+        .thenReturn(Optional.empty());
+
+    // when
+    UpdateNotySettingResponse response = service.update(auctionId, request, userId);
+
+    // then
+    assertTrue(response.auctionStart());
+    assertFalse(response.auctionEnd());
+    assertTrue(response.priceReached());
+
+    verify(notificationSettingRepository, times(3)).save(any(NotificationSetting.class));
+  }
+
+  @Test
+  @DisplayName("[알림 세팅 확인1] row가 존재할 때 isEnabled 반환")
+  void isEnabled_returnsCorrectValue() {
+    // given
+    NotificationSetting setting = NotificationSetting.builder()
+        .user(user)
+        .auction(auction)
+        .type(NotificationSettingType.AUCTION_START)
+        .build();
+    setting.updateActivated(true);
+
+    when(notificationSettingRepository.findByUserIdAndAuctionIdAndType(
+        userId, auctionId, NotificationSettingType.AUCTION_START))
+        .thenReturn(Optional.of(setting));
+
+    // when
+    boolean enabled = service.isEnabled(userId, auctionId, NotificationSettingType.AUCTION_START);
+
+    // then
+    assertTrue(enabled);
+  }
+
+  @Test
+  @DisplayName("[알림 세팅 확인2] row가 없을 때 isEnabled 반환 false")
+  void isEnabled_returnsFalseIfNoRow() {
+    // given
+    when(notificationSettingRepository.findByUserIdAndAuctionIdAndType(
+        userId, auctionId, NotificationSettingType.AUCTION_START))
+        .thenReturn(Optional.empty());
+
+    // when
+    boolean enabled = service.isEnabled(userId, auctionId, NotificationSettingType.AUCTION_START);
+
+    // then
+    assertFalse(enabled);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #106 

## 📝 변경 사항
### AS-IS
- 알림 세팅 CRU 부재

### TO-BE
- 알림 세팅 엔티티 변경 
  - 유니크 키 추가(user_id, auction_Id, type)
  - type 타입 변경(NotificationSettingType)
  - BaseEntity에 메서드 추가
- 알림 세팅 CRU 구현
  - 조회, 수정(+ 생성) 메서드 추가
- 테스트 코드 추가
- 스웨거 기본 틀 추가(머지되면 추후에 완성할 예정)

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 전에 논의한 대로 구현이 되었는지 확인 부탁드립니다!
- 피그마에 맞게 NotificationSetting 엔티티 속성 중 **type**의 enum을 새로 만들었는데 이 부분 체크 부탁드립니다.
- AI가 알림 발송 판단용으로 서비스 클래스에 `isEnabled() `라는 메서드가 있으면 좋을 것 같다고 해서 추가해봤습니다
- 놓친 부분이 있을 것 같아서,, 편하게 피드백 주세요~!