### PR TITLE
[Feature] 알림 조회, 단건 읽음, 전체 읽음 기능 구현 및 테스트

### DIFF
--- a/src/main/java/com/windfall/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.windfall.api.notification.controller;
 
+import com.windfall.api.notification.dto.response.NotificationMarkResponse;
 import com.windfall.api.notification.dto.response.NotificationReadResponse;
 import com.windfall.api.notification.service.NotificationService;
 import com.windfall.domain.user.entity.CustomUserDetails;
@@ -12,6 +13,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,4 +38,13 @@ public class NotificationController implements NotificationSpecification{
     return ApiResponse.ok("알림 조회에 성공했습니다.",response);
   }
 
+  @Override
+  @PatchMapping("{notificationId}")
+  public ApiResponse<NotificationMarkResponse> markAsRead(
+      @PathVariable Long notificationId,
+      @AuthenticationPrincipal CustomUserDetails user
+  ) {
+    NotificationMarkResponse response = notificationService.markAsRead(notificationId,user);
+    return ApiResponse.ok("알림이 읽음 처리되었습니다.",response);
+  }
 }

--- a/src/main/java/com/windfall/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/notifications/")
+@RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
 public class NotificationController implements NotificationSpecification{
 
@@ -40,7 +40,7 @@ public class NotificationController implements NotificationSpecification{
   }
 
   @Override
-  @PatchMapping("{notificationId}")
+  @PatchMapping("/{notificationId}")
   public ApiResponse<NotificationMarkResponse> markAsRead(
       @PathVariable Long notificationId,
       @AuthenticationPrincipal CustomUserDetails user

--- a/src/main/java/com/windfall/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.windfall.api.notification.controller;
 
+import com.windfall.api.notification.dto.response.NotificationMarkAllResponse;
 import com.windfall.api.notification.dto.response.NotificationMarkResponse;
 import com.windfall.api.notification.dto.response.NotificationReadResponse;
 import com.windfall.api.notification.service.NotificationService;
@@ -46,5 +47,14 @@ public class NotificationController implements NotificationSpecification{
   ) {
     NotificationMarkResponse response = notificationService.markAsRead(notificationId,user);
     return ApiResponse.ok("알림이 읽음 처리되었습니다.",response);
+  }
+
+  @Override
+  @PatchMapping
+  public ApiResponse<NotificationMarkAllResponse> markAllAsRead(
+      @AuthenticationPrincipal CustomUserDetails user
+  ) {
+    NotificationMarkAllResponse response = notificationService.markAllAsRead(user);
+    return ApiResponse.ok("알림이 모두 읽음 처리되었습니다.",response);
   }
 }

--- a/src/main/java/com/windfall/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationController.java
@@ -1,0 +1,38 @@
+package com.windfall.api.notification.controller;
+
+import com.windfall.api.notification.dto.response.NotificationReadResponse;
+import com.windfall.api.notification.service.NotificationService;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import com.windfall.global.response.SliceResponse;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications/")
+@RequiredArgsConstructor
+public class NotificationController implements NotificationSpecification{
+
+  private final NotificationService notificationService;
+
+  @Override
+  @GetMapping
+  public ApiResponse<SliceResponse<NotificationReadResponse>> readNotification(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @RequestParam @Min(value = 0, message = "page는 0부터 시작합니다.") int page,
+      @RequestParam(defaultValue = "15") int size
+  ) {
+    PageRequest pageable = PageRequest.of(page, size, Sort.by(Direction.DESC,"createDate"));
+    SliceResponse<NotificationReadResponse> response = notificationService.readNotification(user,pageable);
+    return ApiResponse.ok("알림 조회에 성공했습니다.",response);
+  }
+
+}

--- a/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
@@ -1,10 +1,8 @@
 package com.windfall.api.notification.controller;
 
-import static com.windfall.global.exception.ErrorCode.INVALID_DROP_AMOUNT;
-import static com.windfall.global.exception.ErrorCode.INVALID_IMAGE_STATUS;
-import static com.windfall.global.exception.ErrorCode.INVALID_STOP_LOSS;
-import static com.windfall.global.exception.ErrorCode.INVALID_TIME;
+import static com.windfall.global.exception.ErrorCode.INVALID_NOTIFICATION;
 
+import com.windfall.api.notification.dto.response.NotificationMarkAllResponse;
 import com.windfall.api.notification.dto.response.NotificationMarkResponse;
 import com.windfall.api.notification.dto.response.NotificationReadResponse;
 import com.windfall.domain.user.entity.CustomUserDetails;
@@ -33,9 +31,15 @@ public interface NotificationSpecification {
       @RequestParam(defaultValue = "15") int size
   );
 
+  @ApiErrorCodes(INVALID_NOTIFICATION)
   @Operation(summary = "알림 단건 읽음 처리", description = "알림을 단건 읽음 처리합니다.")
   ApiResponse<NotificationMarkResponse> markAsRead(
       @PathVariable Long notificationId,
+      @AuthenticationPrincipal CustomUserDetails user
+  );
+
+  @Operation(summary = "알림 다건 읽음 처리", description = "알림을 다건 읽음 처리합니다.")
+  ApiResponse<NotificationMarkAllResponse> markAllAsRead(
       @AuthenticationPrincipal CustomUserDetails user
   );
 }

--- a/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
@@ -5,6 +5,7 @@ import static com.windfall.global.exception.ErrorCode.INVALID_IMAGE_STATUS;
 import static com.windfall.global.exception.ErrorCode.INVALID_STOP_LOSS;
 import static com.windfall.global.exception.ErrorCode.INVALID_TIME;
 
+import com.windfall.api.notification.dto.response.NotificationMarkResponse;
 import com.windfall.api.notification.dto.response.NotificationReadResponse;
 import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.config.swagger.ApiErrorCodes;
@@ -15,12 +16,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Notification", description = "알림 API")
 public interface NotificationSpecification {
 
-  @ApiErrorCodes({INVALID_TIME, INVALID_STOP_LOSS, INVALID_DROP_AMOUNT,INVALID_IMAGE_STATUS})
   @Operation(summary = "알림 조회", description = "알림을 조회합니다.")
   ApiResponse<SliceResponse<NotificationReadResponse>> readNotification(
       @AuthenticationPrincipal CustomUserDetails user,
@@ -30,5 +31,11 @@ public interface NotificationSpecification {
 
       @Parameter(description = "한 페이지 사이즈", example = "15")
       @RequestParam(defaultValue = "15") int size
+  );
+
+  @Operation(summary = "알림 단건 읽음 처리", description = "알림을 단건 읽음 처리합니다.")
+  ApiResponse<NotificationMarkResponse> markAsRead(
+      @PathVariable Long notificationId,
+      @AuthenticationPrincipal CustomUserDetails user
   );
 }

--- a/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
@@ -1,0 +1,34 @@
+package com.windfall.api.notification.controller;
+
+import static com.windfall.global.exception.ErrorCode.INVALID_DROP_AMOUNT;
+import static com.windfall.global.exception.ErrorCode.INVALID_IMAGE_STATUS;
+import static com.windfall.global.exception.ErrorCode.INVALID_STOP_LOSS;
+import static com.windfall.global.exception.ErrorCode.INVALID_TIME;
+
+import com.windfall.api.notification.dto.response.NotificationReadResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.config.swagger.ApiErrorCodes;
+import com.windfall.global.response.ApiResponse;
+import com.windfall.global.response.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Notification", description = "알림 API")
+public interface NotificationSpecification {
+
+  @ApiErrorCodes({INVALID_TIME, INVALID_STOP_LOSS, INVALID_DROP_AMOUNT,INVALID_IMAGE_STATUS})
+  @Operation(summary = "알림 조회", description = "알림을 조회합니다.")
+  ApiResponse<SliceResponse<NotificationReadResponse>> readNotification(
+      @AuthenticationPrincipal CustomUserDetails user,
+
+      @Parameter(description = "현재 페이지", example = "1")
+      @RequestParam @Min(value = 0,message = "page는 0부터 시작합니다.") int page,
+
+      @Parameter(description = "한 페이지 사이즈", example = "15")
+      @RequestParam(defaultValue = "15") int size
+  );
+}

--- a/src/main/java/com/windfall/api/notification/dto/response/NotificationMarkAllResponse.java
+++ b/src/main/java/com/windfall/api/notification/dto/response/NotificationMarkAllResponse.java
@@ -1,0 +1,10 @@
+package com.windfall.api.notification.dto.response;
+
+public record NotificationMarkAllResponse(
+    Long userId,
+    long updatedCount
+) {
+  public static NotificationMarkAllResponse of(Long userId, long updatedCount){
+    return new NotificationMarkAllResponse(userId,updatedCount);
+  }
+}

--- a/src/main/java/com/windfall/api/notification/dto/response/NotificationMarkResponse.java
+++ b/src/main/java/com/windfall/api/notification/dto/response/NotificationMarkResponse.java
@@ -2,28 +2,22 @@ package com.windfall.api.notification.dto.response;
 
 import com.windfall.domain.notification.entity.Notification;
 import com.windfall.domain.notification.enums.NotificationType;
-import java.time.LocalDateTime;
 
-public record NotificationReadResponse(
+public record NotificationMarkResponse(
     Long notificationId,
-    NotificationType type,
-    String title,
-    String message,
     Boolean readStatus,
+    NotificationType type,
     String target,
-    Long targetId,
-    LocalDateTime notificationAt
+    Long targetId
 ) {
-  public static NotificationReadResponse from(Notification notification){
-    return new NotificationReadResponse(
+
+  public static NotificationMarkResponse from(Notification notification) {
+    return new NotificationMarkResponse(
         notification.getId(),
-        notification.getType(),
-        notification.getTitle(),
-        notification.getMessage(),
         notification.getReadStatus(),
+        notification.getType(),
         setTarget(notification.getType()),
-        notification.getTargetId(),
-        notification.getCreateDate()
+        notification.getTargetId()
     );
   }
 

--- a/src/main/java/com/windfall/api/notification/dto/response/NotificationMarkResponse.java
+++ b/src/main/java/com/windfall/api/notification/dto/response/NotificationMarkResponse.java
@@ -16,22 +16,8 @@ public record NotificationMarkResponse(
         notification.getId(),
         notification.getReadStatus(),
         notification.getType(),
-        setTarget(notification.getType()),
+        notification.getType().getTarget(),
         notification.getTargetId()
     );
-  }
-
-  private static String setTarget(NotificationType type){
-    if(type == NotificationType.CHAT_MESSAGE){
-      return "chatRoom";
-    }
-    if (type == NotificationType.REVIEW_REGISTERED){
-      return "review";
-    }
-    if(type == NotificationType.PURCHASE_CONFIRMED_SELLER){
-      return "payment";
-    }
-
-    return "auction";
   }
 }

--- a/src/main/java/com/windfall/api/notification/dto/response/NotificationReadResponse.java
+++ b/src/main/java/com/windfall/api/notification/dto/response/NotificationReadResponse.java
@@ -1,0 +1,25 @@
+package com.windfall.api.notification.dto.response;
+
+import com.windfall.domain.notification.entity.Notification;
+import com.windfall.domain.notification.enums.NotificationType;
+import java.time.LocalDateTime;
+
+public record NotificationReadResponse(
+    NotificationType type,
+    String title,
+    String message,
+    Boolean readStatus,
+    Long targetId,
+    LocalDateTime notificationAt
+) {
+  public static NotificationReadResponse from(Notification notification){
+    return new NotificationReadResponse(
+        notification.getType(),
+        notification.getTitle(),
+        notification.getMessage(),
+        notification.getReadStatus(),
+        notification.getTargetId(),
+        notification.getCreateDate()
+    );
+  }
+}

--- a/src/main/java/com/windfall/api/notification/dto/response/NotificationReadResponse.java
+++ b/src/main/java/com/windfall/api/notification/dto/response/NotificationReadResponse.java
@@ -21,23 +21,9 @@ public record NotificationReadResponse(
         notification.getTitle(),
         notification.getMessage(),
         notification.getReadStatus(),
-        setTarget(notification.getType()),
+        notification.getType().getTarget(),
         notification.getTargetId(),
         notification.getCreateDate()
     );
-  }
-
-  private static String setTarget(NotificationType type){
-    if(type == NotificationType.CHAT_MESSAGE){
-      return "chatRoom";
-    }
-    if (type == NotificationType.REVIEW_REGISTERED){
-      return "review";
-    }
-    if(type == NotificationType.PURCHASE_CONFIRMED_SELLER){
-      return "payment";
-    }
-
-    return "auction";
   }
 }

--- a/src/main/java/com/windfall/api/notification/dto/response/NotificationReadResponse.java
+++ b/src/main/java/com/windfall/api/notification/dto/response/NotificationReadResponse.java
@@ -5,6 +5,7 @@ import com.windfall.domain.notification.enums.NotificationType;
 import java.time.LocalDateTime;
 
 public record NotificationReadResponse(
+    Long notificationId,
     NotificationType type,
     String title,
     String message,
@@ -14,6 +15,7 @@ public record NotificationReadResponse(
 ) {
   public static NotificationReadResponse from(Notification notification){
     return new NotificationReadResponse(
+        notification.getId(),
         notification.getType(),
         notification.getTitle(),
         notification.getMessage(),

--- a/src/main/java/com/windfall/api/notification/service/NotificationService.java
+++ b/src/main/java/com/windfall/api/notification/service/NotificationService.java
@@ -1,0 +1,26 @@
+package com.windfall.api.notification.service;
+
+import com.windfall.api.notification.dto.response.NotificationReadResponse;
+import com.windfall.domain.notification.entity.Notification;
+import com.windfall.domain.notification.repository.NotificationRepository;
+import com.windfall.domain.user.entity.CustomUserDetails;
+
+import com.windfall.global.response.SliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+
+
+  public SliceResponse<NotificationReadResponse> readNotification(CustomUserDetails user, Pageable pageable) {
+    Slice<Notification> notifications = notificationRepository.findByUserId(user.getUserId(), pageable);
+    Slice<NotificationReadResponse> responseSlice = notifications.map(NotificationReadResponse::from);
+    return SliceResponse.from(responseSlice);
+  }
+}

--- a/src/main/java/com/windfall/api/notification/service/NotificationService.java
+++ b/src/main/java/com/windfall/api/notification/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.windfall.api.notification.service;
 
+import com.windfall.api.notification.dto.response.NotificationMarkAllResponse;
 import com.windfall.api.notification.dto.response.NotificationMarkResponse;
 import com.windfall.api.notification.dto.response.NotificationReadResponse;
 import com.windfall.domain.notification.entity.Notification;
@@ -32,14 +33,27 @@ public class NotificationService {
   public NotificationMarkResponse markAsRead(Long notificationId, CustomUserDetails user) {
     Notification notification = getNotification(notificationId);
 
+    validateUser(notification,user);
+
     notification.updateReadStatus(true);
 
-
     return NotificationMarkResponse.from(notification);
+  }
+
+  @Transactional
+  public NotificationMarkAllResponse markAllAsRead(CustomUserDetails user) {
+    long updatedCount = notificationRepository.markAllAsRead(user.getUserId());
+    return NotificationMarkAllResponse.of(user.getUserId(),updatedCount);
   }
 
   private Notification getNotification(Long notificationId){
     return notificationRepository.findById(notificationId)
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_NOTIFICATION));
+  }
+
+  private void validateUser(Notification notification, CustomUserDetails user) {
+    if (notification.getUser() == null || !notification.getUser().getId().equals(user.getUserId())) {
+      throw new ErrorException(ErrorCode.INVALID_NOTIFICATION);
+    }
   }
 }

--- a/src/main/java/com/windfall/api/notification/service/NotificationService.java
+++ b/src/main/java/com/windfall/api/notification/service/NotificationService.java
@@ -1,15 +1,19 @@
 package com.windfall.api.notification.service;
 
+import com.windfall.api.notification.dto.response.NotificationMarkResponse;
 import com.windfall.api.notification.dto.response.NotificationReadResponse;
 import com.windfall.domain.notification.entity.Notification;
 import com.windfall.domain.notification.repository.NotificationRepository;
 import com.windfall.domain.user.entity.CustomUserDetails;
 
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
 import com.windfall.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,5 +26,20 @@ public class NotificationService {
     Slice<Notification> notifications = notificationRepository.findByUserId(user.getUserId(), pageable);
     Slice<NotificationReadResponse> responseSlice = notifications.map(NotificationReadResponse::from);
     return SliceResponse.from(responseSlice);
+  }
+
+  @Transactional
+  public NotificationMarkResponse markAsRead(Long notificationId, CustomUserDetails user) {
+    Notification notification = getNotification(notificationId);
+
+    notification.updateReadStatus(true);
+
+
+    return NotificationMarkResponse.from(notification);
+  }
+
+  private Notification getNotification(Long notificationId){
+    return notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_NOTIFICATION));
   }
 }

--- a/src/main/java/com/windfall/domain/notification/entity/Notification.java
+++ b/src/main/java/com/windfall/domain/notification/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.windfall.domain.notification.entity;
 
+import com.windfall.api.notification.dto.response.NotificationMarkResponse;
 import com.windfall.domain.notification.enums.NotificationType;
 import com.windfall.domain.user.entity.User;
 import com.windfall.global.entity.BaseEntity;
@@ -53,5 +54,10 @@ public class Notification extends BaseEntity {
         .type(type)
         .targetId(targetId)
         .build();
+  }
+
+
+  public void updateReadStatus(Boolean readStatus) {
+    this.readStatus = readStatus;
   }
 }

--- a/src/main/java/com/windfall/domain/notification/entity/Notification.java
+++ b/src/main/java/com/windfall/domain/notification/entity/Notification.java
@@ -40,13 +40,18 @@ public class Notification extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private NotificationType type;
 
-  public static Notification create(User user, String title, String message, Boolean readStatus, NotificationType type){
+  // target의 id
+  @Column(nullable = false)
+  private Long targetId;
+
+  public static Notification create(User user, String title, String message, Boolean readStatus, NotificationType type,Long targetId){
     return Notification.builder()
         .user(user)
         .title(title)
         .message(message)
         .readStatus(readStatus)
         .type(type)
+        .targetId(targetId)
         .build();
   }
 }

--- a/src/main/java/com/windfall/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/windfall/domain/notification/enums/NotificationType.java
@@ -8,31 +8,32 @@ import lombok.Getter;
 public enum NotificationType {
 
   // 채팅
-  CHAT_MESSAGE("채팅 알림"),
+  CHAT_MESSAGE("채팅 알림","chatRoom"),
 
   // 경매 시작
-  AUCTION_START_WISHLIST("거래 시작"),
+  AUCTION_START_WISHLIST("거래 시작","auction"),
 
   // 경매 유찰
-  AUCTION_FAILED_SELLER("거래 유찰 (판매자)"),
-  AUCTION_FAILED_BUYER("거래 유찰 (구매자)"),
+  AUCTION_FAILED_SELLER("거래 유찰 (판매자)","auction"),
+  AUCTION_FAILED_BUYER("거래 유찰 (구매자)","auction"),
 
   // 경매 종료 (내 물건 아님)
-  AUCTION_ENDED_OTHER("남의 물건 경매 종료"),
+  AUCTION_ENDED_OTHER("남의 물건 경매 종료","auction"),
 
   // 가격 변동
-  STOP_LOSS_TRIGGERED("스탑 로스 발생"),
-  PRICE_DROP("가격 하락"),
+  STOP_LOSS_TRIGGERED("스탑 로스 발생","auction"),
+  PRICE_DROP("가격 하락","auction"),
 
   // 거래 성공
-  SALE_SUCCESS_SELLER("판매 성공 (판매자)"),
-  PAYMENT_SUCCESS_BUYER("결제 성공 (구매자)"),
+  SALE_SUCCESS_SELLER("판매 성공 (판매자)","auction"),
+  PAYMENT_SUCCESS_BUYER("결제 성공 (구매자)","auction"),
 
   // 구매 확정
-  PURCHASE_CONFIRMED_SELLER("구매 확정 (판매자)"),
+  PURCHASE_CONFIRMED_SELLER("구매 확정 (판매자)","payment"),
 
   // 리뷰
-  REVIEW_REGISTERED("리뷰 등록");
+  REVIEW_REGISTERED("리뷰 등록","review");
 
   private final String description;
+  private final String target;
 }

--- a/src/main/java/com/windfall/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/windfall/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,10 @@
 package com.windfall.domain.notification.repository;
 
 import com.windfall.domain.notification.entity.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification,Long> {
+  Slice<Notification> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/windfall/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/windfall/domain/notification/repository/NotificationRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NotificationRepository extends JpaRepository<Notification,Long> {
+public interface NotificationRepository extends JpaRepository<Notification,Long>, NotificationRepositoryCustom {
   Slice<Notification> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/windfall/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/windfall/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.windfall.domain.notification.repository;
+
+public interface NotificationRepositoryCustom  {
+  long markAllAsRead(Long userId);
+}

--- a/src/main/java/com/windfall/domain/notification/repository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/windfall/domain/notification/repository/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,20 @@
+package com.windfall.domain.notification.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import static com.windfall.domain.notification.entity.QNotification.notification;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public long markAllAsRead(Long userId) {
+    return queryFactory
+        .update(notification)
+        .set(notification.readStatus,true)
+        .where(notification.user.id.eq(userId)
+            .and(notification.readStatus.isFalse()))
+        .execute();
+  }
+}

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
 
   //알림
   NOT_FOUND_NOTIFICATION(HttpStatus.NOT_FOUND,"존재하지 않는 알림입니다."),
-
+  INVALID_NOTIFICATION(HttpStatus.FORBIDDEN, "해당 유저의 알림이 아닙니다."),
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")
   ;

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
   INVALID_S3_UPLOAD(HttpStatus.BAD_GATEWAY,"S3 이미지 업로드 실패했습니다."),
   INVALID_IMAGE_STATUS(HttpStatus.BAD_REQUEST, "경매에 연결할 수 없는 이미지 상태입니다."),
 
+  //알림
+  NOT_FOUND_NOTIFICATION(HttpStatus.NOT_FOUND,"존재하지 않는 알림입니다."),
 
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")

--- a/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
@@ -6,18 +6,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.windfall.api.auction.controller.AuctionController;
-import com.windfall.api.auction.dto.request.AuctionCreateRequest;
-import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.notification.entity.Notification;
 import com.windfall.domain.notification.enums.NotificationType;
 import com.windfall.domain.notification.repository.NotificationRepository;
 import com.windfall.domain.user.entity.User;
 import com.windfall.domain.user.enums.ProviderType;
 import com.windfall.global.jwt.JwtTest;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,105 @@
+package com.windfall.api.notification.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.windfall.domain.notification.entity.Notification;
+import com.windfall.domain.notification.enums.NotificationType;
+import com.windfall.domain.notification.repository.NotificationRepository;
+import com.windfall.global.jwt.JwtTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationControllerTest extends JwtTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private NotificationRepository notificationRepository;
+
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+
+
+
+  @BeforeEach
+  void setUp() {
+
+    Notification notification1 = Notification.create(
+        mockUser,
+        "테스트 제목",
+        "테스트 메시지",
+        false,
+        NotificationType.PRICE_DROP,
+        1L);
+
+    Notification notification2 = Notification.create(
+        mockUser,
+        "테스트 제목",
+        "테스트 메시지",
+        false,
+        NotificationType.PRICE_DROP,
+        2L);
+    notificationRepository.save(notification1);
+    notificationRepository.save(notification2);
+  }
+
+  @Nested
+  @DisplayName("알림 조회 API")
+  class t1 {
+
+    @Test
+    @DisplayName("정상 작동")
+    void success() throws Exception {
+      // given
+
+
+      //when
+      ResultActions resultActions = mockMvc.perform(
+          get("/api/v1/notifications/")
+              .accept(MediaType.APPLICATION_JSON)
+              .contentType(MediaType.APPLICATION_JSON)
+              .param("page","0")
+      );
+
+      // then
+      resultActions
+          .andExpect(handler().handlerType(NotificationController.class))
+          .andExpect(handler().methodName("readNotification"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.status").value("OK"))
+          .andExpect(jsonPath("$.message").value("알림 조회에 성공했습니다."))
+          .andExpect(jsonPath("$.data.timeStamp").exists())
+          .andExpect(jsonPath("$.data.page").value(0))
+          .andExpect(jsonPath("$.data.size").value(15))
+          .andExpect(jsonPath("$.data.hasNext").value(false))
+          .andExpect(jsonPath("$.data.slice[0].type").value("PRICE_DROP"))
+          .andExpect(jsonPath("$.data.slice[0].title").value("테스트 제목"))
+          .andExpect(jsonPath("$.data.slice[0].message").value("테스트 메시지"))
+          .andExpect(jsonPath("$.data.slice[0].readStatus").value(false))
+          .andExpect(jsonPath("$.data.slice[0].notificationAt").exists())
+          .andExpect(jsonPath("$.data.slice[0].targetId").value(2L))
+          .andDo(print());
+    }
+
+  }
+}

--- a/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
@@ -78,7 +78,7 @@ class NotificationControllerTest extends JwtTest {
       // given
       // when
       ResultActions resultActions = mockMvc.perform(
-          get("/api/v1/notifications/")
+          get("/api/v1/notifications")
               .accept(MediaType.APPLICATION_JSON)
               .contentType(MediaType.APPLICATION_JSON)
               .param("page","0")
@@ -211,7 +211,7 @@ class NotificationControllerTest extends JwtTest {
 
       //when
       ResultActions resultActions = mockMvc.perform(
-          patch("/api/v1/notifications/")
+          patch("/api/v1/notifications")
               .accept(MediaType.APPLICATION_JSON)
               .contentType(MediaType.APPLICATION_JSON)
       );

--- a/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
@@ -174,6 +174,29 @@ class NotificationControllerTest extends JwtTest {
           .andExpect(jsonPath("$.message").value("해당 유저의 알림이 아닙니다."))
           .andDo(print());
     }
+
+    @Test
+    @DisplayName("존재하지 않는 알림일 때")
+    void fail2() throws Exception{
+      // given
+      notificationId = 9999L;
+
+      //when
+      ResultActions resultActions = mockMvc.perform(
+          patch("/api/v1/notifications/%s".formatted(notificationId))
+              .accept(MediaType.APPLICATION_JSON)
+              .contentType(MediaType.APPLICATION_JSON)
+      );
+
+      // then
+      resultActions
+          .andExpect(handler().handlerType(NotificationController.class))
+          .andExpect(handler().methodName("markAsRead"))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.status").value("NOT_FOUND"))
+          .andExpect(jsonPath("$.message").value("존재하지 않는 알림입니다."))
+          .andDo(print());
+    }
   }
 
   @Nested

--- a/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/windfall/api/notification/controller/NotificationControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.windfall.domain.notification.entity.Notification;
 import com.windfall.domain.notification.enums.NotificationType;
 import com.windfall.domain.notification.repository.NotificationRepository;
@@ -35,8 +34,6 @@ class NotificationControllerTest extends JwtTest {
   private NotificationRepository notificationRepository;
 
 
-  @Autowired
-  private ObjectMapper objectMapper;
 
   private Long notificationId;
 
@@ -145,7 +142,7 @@ class NotificationControllerTest extends JwtTest {
 
       //when
       ResultActions resultActions = mockMvc.perform(
-          patch("/api/v1/notifications")
+          patch("/api/v1/notifications/")
               .accept(MediaType.APPLICATION_JSON)
               .contentType(MediaType.APPLICATION_JSON)
       );
@@ -153,10 +150,12 @@ class NotificationControllerTest extends JwtTest {
       // then
       resultActions
           .andExpect(handler().handlerType(NotificationController.class))
-          .andExpect(handler().methodName("markAsRead"))
+          .andExpect(handler().methodName("markAllAsRead"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.status").value("OK"))
           .andExpect(jsonPath("$.message").value("알림이 모두 읽음 처리되었습니다."))
+          .andExpect(jsonPath("$.data.userId").value(mockUser.getId()))
+          .andExpect(jsonPath("$.data.updatedCount").value(2))
           .andDo(print());
     }
   }

--- a/src/test/java/com/windfall/global/jwt/JwtTest.java
+++ b/src/test/java/com/windfall/global/jwt/JwtTest.java
@@ -1,0 +1,49 @@
+package com.windfall.global.jwt;
+
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.enums.ProviderType;
+import com.windfall.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class JwtTest{
+
+  @Autowired
+  protected UserRepository userRepository;
+
+
+  protected User mockUser;
+
+  @BeforeEach
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  void setUp() {
+
+    User user = User.builder()
+        .email("test@naver.com")
+        .provider(ProviderType.NAVER)
+        .providerUserId("test1234")
+        .nickname("testNickname")
+        .build();
+
+    mockUser = userRepository.save(user);
+
+    CustomUserDetails userDetails = new CustomUserDetails(mockUser);
+
+    Authentication auth = new UsernamePasswordAuthenticationToken(
+        userDetails, null, userDetails.getAuthorities()
+    );
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #89

## 📝 변경 사항
### AS-IS

### TO-BE
- 조회
  - 무한 스크롤로 구현 (최신 값 정렬 고정)
  - JwtTest라는 추상 테스트 코드 추가 -> 로그인이 되었을 경우를 직접 등록 mockUser로 데이터를 반입
  - 성공 테스트 
- 단건 읽음 처리
  - target 메소드 중복 생성 -> 메소드 삭제 후 type enum의 getTarget를 추가
  - 성공 테스트, 실패 테스트
- 전체 읽음 처리
  - 벌크 업데이트 방식 선택
    - why? 참조 링크 : [Spring Batch 애플리케이션 성능 향상을 위한 주요 팁](https://tech.kakaopay.com/post/spring-batch-performance/)
      - 단건 수정이 아닌 다건 수정이어서 성능적 문제 발생 (더티 체킹을 선택 안 한 이유이지만, 단점으로 벌크 연산은 영속성 컨텍스트를 무시합니다.) 
      - readStatus를 true로 변동하는 일괄 처리 로직이기 때문에 (가장 큰 이유 -> JDBC 방식을 선택 안 한 이유)
      - 객체 지향성을 챙길 수 있는 가독성 있는 코드라고 생각되어서 
## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="578" height="624" alt="image" src="https://github.com/user-attachments/assets/9da68bfb-f13d-4146-85ab-de4fc15d5c66" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
가독성 있는 코드는 무엇일까? 늘 고민되는 문제입니다. 혹시라도 부족한 점이 있으면 편하게 코드 리뷰 달아주세여!!