### PR TITLE
[Refactor] 유저정보 API loginId 필드 제거 및 쿠키(AuthenticationPrincipal) 기반 동작으로 재설정

### DIFF
--- a/src/main/java/com/windfall/api/user/controller/UserInfoSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/UserInfoSpecification.java
@@ -2,12 +2,14 @@ package com.windfall.api.user.controller;
 
 import com.windfall.api.user.dto.response.UserInfoResponse;
 import com.windfall.api.user.dto.response.saleshistory.BaseSalesHistoryResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import com.windfall.global.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -15,12 +17,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface UserInfoSpecification {
 
   @Operation(summary = "사용자 정보", description = "특정 사용자의 정보를 반환합니다.")
-  ApiResponse<UserInfoResponse> getUserInfo(@PathVariable Long userid, @RequestParam Long loginId);
+  ApiResponse<UserInfoResponse> getUserInfo(
+      @PathVariable Long userid,
+      @AuthenticationPrincipal
+      CustomUserDetails userDetails);
 
   @Operation(summary = "사용자 판매 내역", description = "특정 사용자의 판매 내역을 반환합니다.")
   ApiResponse<SliceResponse<BaseSalesHistoryResponse>> getUserSalesHistory(
       @PathVariable Long userid,
-      @RequestParam Long loginId,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestParam(required = false) String filter,
       @PageableDefault(page = 0, size = 10) Pageable pageable
 

--- a/src/main/java/com/windfall/api/user/controller/UserinfoController.java
+++ b/src/main/java/com/windfall/api/user/controller/UserinfoController.java
@@ -3,11 +3,13 @@ package com.windfall.api.user.controller;
 import com.windfall.api.user.dto.response.UserInfoResponse;
 import com.windfall.api.user.dto.response.saleshistory.BaseSalesHistoryResponse;
 import com.windfall.api.user.service.UserInfoService;
+import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import com.windfall.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +27,9 @@ public class UserinfoController implements UserInfoSpecification{
   @GetMapping("/{userid}")
   public ApiResponse<UserInfoResponse> getUserInfo(
       @PathVariable Long userid,
-      @RequestParam(defaultValue = "1") Long loginId) {
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    Long loginId = userDetails.getUserId();
+
     UserInfoResponse response = userInfoService.getUserInfo(userid, loginId);
 
     return ApiResponse.ok("사용자 정보 조회에 성공했습니다.", response);
@@ -35,9 +39,11 @@ public class UserinfoController implements UserInfoSpecification{
   @GetMapping("/{userid}/sales")
   public ApiResponse<SliceResponse<BaseSalesHistoryResponse>> getUserSalesHistory(
       @PathVariable Long userid,
-      @RequestParam(defaultValue = "1") Long loginId,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestParam(required = false) String filter,
       @PageableDefault(page = 0, size = 10) Pageable pageable) {
+
+    Long loginId = userDetails.getUserId();
 
     SliceResponse<BaseSalesHistoryResponse> response = userInfoService.getUserSalesHistory(userid, loginId, filter, pageable);
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #113 

## 📝 변경 사항
### AS-IS
- UserInfo, SalesHistory에서 UserDetails가 구현되었는데도 불구하고 RequestParam으로 유저 id를 받고 있었음.

### TO-BE
- RequestParam대신 AuthenticationPricipal로 실제 인증을 거친 userid를 받도록 리팩토링

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
간단한 리팩토링입니다!