### PR TITLE
[Feature] 알림 세팅 스웨거 • 피드백 반영

### DIFF
--- a/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
+++ b/src/main/java/com/windfall/api/like/controller/AuctionLikeController.java
@@ -1,8 +1,11 @@
 package com.windfall.api.like.controller;
 
+import static com.windfall.global.exception.ErrorCode.INVALID_TOKEN;
+
 import com.windfall.api.like.dto.response.AuctionLikeResponse;
 import com.windfall.api.like.service.AuctionLikeService;
 import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.exception.ErrorException;
 import com.windfall.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +27,12 @@ public class AuctionLikeController implements AuctionLikeSpecification {
       @PathVariable Long auctionId,
       @AuthenticationPrincipal CustomUserDetails user
   ) {
+
+    // 프론트 요청으로 추가(제거 예정)
+    if (user == null) {
+      throw new ErrorException(INVALID_TOKEN);
+    }
+
     AuctionLikeResponse response = auctionLikeService.toggleLike(auctionId, user.getUserId());
     return ApiResponse.ok("찜 토글을 성공했습니다.", response);
   }

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
@@ -22,6 +22,7 @@ public class NotificationSettingController implements NotificationSettingSpecifi
 
   private final NotificationSettingService notificationSettingService;
 
+  @Override
   @GetMapping
   public ApiResponse<ReadNotySettingResponse> read(
       @PathVariable Long auctionId,
@@ -32,6 +33,7 @@ public class NotificationSettingController implements NotificationSettingSpecifi
     return ApiResponse.ok("알림 세팅 조회를 성공했습니다.", response);
   }
 
+  @Override
   @PutMapping
   public ApiResponse<UpdateNotySettingResponse> update(
       @PathVariable Long auctionId,

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
@@ -1,8 +1,52 @@
 package com.windfall.api.notificationsetting.controller;
 
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_AUCTION;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_USER;
+
+import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
+import com.windfall.api.notificationsetting.dto.response.ReadNotySettingResponse;
+import com.windfall.api.notificationsetting.dto.response.UpdateNotySettingResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.config.swagger.ApiErrorCodes;
+import com.windfall.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Notification Setting", description = "알림 세팅 API")
 public interface NotificationSettingSpecification {
 
+  @Operation(summary = "알림 세팅 조회", description = "알림 세팅을 조회합니다.")
+  ApiResponse<ReadNotySettingResponse> read(
+      @Parameter(description = "경매 ID", required = true, example = "1")
+      @PathVariable Long auctionId,
+
+      @Parameter(description = "사용자 ID", example = "1")
+      @AuthenticationPrincipal CustomUserDetails user
+  );
+
+  @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_AUCTION})
+  @Operation(summary = "알림 세팅 수정", description = "알림 세팅을 수정합니다.")
+  ApiResponse<UpdateNotySettingResponse> update(
+      @Parameter(description = "경매 ID", required = true, example = "1")
+      @PathVariable Long auctionId,
+
+      @Parameter(description = "알림 여부", required = true,
+          example =
+              """
+              {
+                "auctionStart": true,
+                "auctionEnd": true,
+                "priceReached": true
+              }
+              """
+      )
+      @RequestBody UpdateNotySettingRequest request,
+
+      @Parameter(description = "사용자 ID", example = "1")
+      @AuthenticationPrincipal CustomUserDetails user
+  );
 }

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -67,11 +67,15 @@ public class NotificationSettingService {
   ) {
     NotificationSetting setting = notificationSettingRepository
         .findByUserIdAndAuctionIdAndType(user.getId(), auction.getId(), type)
-        .orElseGet(() -> NotificationSetting.create(user, auction, type)
-        );
+        .orElse(null);
 
-    setting.updateActivated(activated);
-    notificationSettingRepository.save(setting);
+    if (setting == null) {
+      setting = NotificationSetting.create(user, auction, type);
+      setting.updateActivated(activated);
+      notificationSettingRepository.save(setting);
+    } else {
+      setting.updateActivated(activated);
+    }
   }
 
   // 알림 발송 판단용

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -66,16 +66,12 @@ public class NotificationSettingService {
       boolean activated
   ) {
     NotificationSetting setting = notificationSettingRepository
-        .findByUserIdAndAuctionIdAndType(user.getId(), auction.getId(), type)
-        .orElse(null);
+            .findByUserIdAndAuctionIdAndType(user.getId(), auction.getId(), type)
+            .orElseGet(() -> notificationSettingRepository.save(
+                NotificationSetting.create(user, auction, type)
+            ));
 
-    if (setting == null) {
-      setting = NotificationSetting.create(user, auction, type);
-      setting.updateActivated(activated);
-      notificationSettingRepository.save(setting);
-    } else {
-      setting.updateActivated(activated);
-    }
+    setting.updateActivated(activated);
   }
 
   // 알림 발송 판단용

--- a/src/test/java/com/windfall/api/notificationsetting/NotificationSettingServiceTest.java
+++ b/src/test/java/com/windfall/api/notificationsetting/NotificationSettingServiceTest.java
@@ -79,6 +79,9 @@ class NotificationSettingServiceTest {
     when(user.getId()).thenReturn(userId);
     when(auction.getId()).thenReturn(auctionId);
 
+    when(notificationSettingRepository.save(any(NotificationSetting.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
     when(notificationSettingRepository.findByUserIdAndAuctionIdAndType(userId, auctionId,
         NotificationSettingType.AUCTION_START))
         .thenReturn(Optional.empty());


### PR DESCRIPTION
## 📌 관련 이슈
- close #111 

## 📝 변경 사항
### AS-IS
- 스웨거 미작성 
- 알림 세팅 로직 중 불필요한 save 호출

### TO-BE
- 알림 세팅 스웨거 작성
- 알림 세팅 로직 보완(if문 추가)하여 save가 필요할 때만 호출하도록 함

## 🔍 테스트
- [x] 테스트 코드 작성 - 테스트 통과
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 스웨거 작성하고 전에 피드백 주신 부분만 반영하였습니다.

++ 추가 
프론트 요청으로 찜 컨트롤러에 userId를 임시 예외처리했습니다. 
추후에 SecurityConfig에서 `.requestMatchers("/**").permitAll()` 제거하면 이것도 제거 하겠습니다.