### PR TITLE
[Feature] 찜 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/windfall/api/mypage/controller/MyPageController.java
+++ b/src/main/java/com/windfall/api/mypage/controller/MyPageController.java
@@ -1,7 +1,10 @@
 package com.windfall.api.mypage.controller;
 
+import com.windfall.api.mypage.dto.auctionlikelist.AuctionLikeListResponse;
+import com.windfall.api.mypage.dto.auctionlikelist.BaseAuctionLikeList;
 import com.windfall.api.mypage.dto.notificationsetlist.BaseNotificationSetList;
 import com.windfall.api.mypage.dto.purchasehistory.BasePurchaseHistory;
+import com.windfall.api.mypage.service.AuctionLikeListService;
 import com.windfall.api.mypage.service.NotificationSetListService;
 import com.windfall.api.mypage.service.PurchaseHistoryService;
 import com.windfall.domain.auction.enums.AuctionStatus;
@@ -10,6 +13,7 @@ import com.windfall.global.response.ApiResponse;
 import com.windfall.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +28,7 @@ public class MyPageController implements MyPageSpecification{
 
   private final PurchaseHistoryService purchaseHistoryService;
   private final NotificationSetListService notificationSetListService;
+  private final AuctionLikeListService auctionLikeListService;
 
   @GetMapping("/purchases")
   public ApiResponse<SliceResponse<BasePurchaseHistory>> getMyPurchaseHistory(
@@ -41,12 +46,25 @@ public class MyPageController implements MyPageSpecification{
   @Override
   @GetMapping("/notifications")
   public ApiResponse<SliceResponse<BaseNotificationSetList>> getMyNotifications(
-      Pageable pageable,
+      @PageableDefault(page = 0, size = 10) Pageable pageable,
       @RequestParam(required = false) AuctionStatus filter,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     Long userId = userDetails.getUserId();
     SliceResponse<BaseNotificationSetList> response = notificationSetListService.getMyNotifications(userId, filter, pageable);
     return ApiResponse.ok("알림내역 조회에 성공하였습니다.", response);
+  }
+
+  @Override
+  @GetMapping("/likes")
+  public ApiResponse<SliceResponse<BaseAuctionLikeList>> getMyAuctionLikes(
+      @PageableDefault(page = 0, size = 10) Pageable pageable,
+      @RequestParam(required = false) AuctionStatus filter,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    Long userId = userDetails.getUserId();
+    SliceResponse<BaseAuctionLikeList> response = auctionLikeListService.getMyAuctionLikes(userId, filter, pageable);
+
+    return ApiResponse.ok("찜 목록 조회에 성공하였습니다.", response);
   }
 }

--- a/src/main/java/com/windfall/api/mypage/controller/MyPageSpecification.java
+++ b/src/main/java/com/windfall/api/mypage/controller/MyPageSpecification.java
@@ -1,5 +1,6 @@
 package com.windfall.api.mypage.controller;
 
+import com.windfall.api.mypage.dto.auctionlikelist.BaseAuctionLikeList;
 import com.windfall.api.mypage.dto.notificationsetlist.BaseNotificationSetList;
 import com.windfall.api.mypage.dto.purchasehistory.BasePurchaseHistory;
 import com.windfall.domain.auction.enums.AuctionStatus;
@@ -27,5 +28,12 @@ public interface MyPageSpecification {
   ApiResponse<SliceResponse<BaseNotificationSetList>> getMyNotifications(@PageableDefault(page = 0, size = 10) Pageable pageable,
       @RequestParam(required = false) AuctionStatus filter,
       @AuthenticationPrincipal CustomUserDetails userDetails
+  );
+
+  @Operation(summary = "나의 찜 목록 조회", description = "자신이 찜한 경매 목록을 조회합니다.")
+  ApiResponse<SliceResponse<BaseAuctionLikeList>> getMyAuctionLikes(@PageableDefault(page = 0, size = 10) Pageable pageable,
+      @RequestParam(required = false) AuctionStatus filter,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+      /*@AuthenticationPrincipal CustomUserDetails userDetails*/
   );
 }

--- a/src/main/java/com/windfall/api/mypage/controller/MyPageSpecification.java
+++ b/src/main/java/com/windfall/api/mypage/controller/MyPageSpecification.java
@@ -34,6 +34,5 @@ public interface MyPageSpecification {
   ApiResponse<SliceResponse<BaseAuctionLikeList>> getMyAuctionLikes(@PageableDefault(page = 0, size = 10) Pageable pageable,
       @RequestParam(required = false) AuctionStatus filter,
       @AuthenticationPrincipal CustomUserDetails userDetails
-      /*@AuthenticationPrincipal CustomUserDetails userDetails*/
   );
 }

--- a/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/AuctionLikeListRaw.java
+++ b/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/AuctionLikeListRaw.java
@@ -1,0 +1,10 @@
+package com.windfall.api.mypage.dto.auctionlikelist;
+
+import com.windfall.domain.auction.enums.AuctionStatus;
+
+public record AuctionLikeListRaw(
+    Long id,
+    AuctionStatus status
+) {
+
+}

--- a/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/AuctionLikeListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/AuctionLikeListResponse.java
@@ -1,0 +1,40 @@
+package com.windfall.api.mypage.dto.auctionlikelist;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.persistence.Tuple;
+import java.sql.Date;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "likeId",
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "startedAt"
+})
+public class AuctionLikeListResponse extends BaseAuctionLikeList{
+
+  @Builder
+  public AuctionLikeListResponse(Long likeId, String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt) {
+    super(likeId, status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+  }
+
+  public static AuctionLikeListResponse from(Tuple tuple){
+    return AuctionLikeListResponse.builder()
+        .likeId(tuple.get("auctionLikeId", Long.class))
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .startedAt(tuple.get("startedAt", Date.class).toLocalDate())
+        .build();
+  }
+
+}

--- a/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/BaseAuctionLikeList.java
+++ b/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/BaseAuctionLikeList.java
@@ -1,0 +1,48 @@
+package com.windfall.api.mypage.dto.auctionlikelist;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+@Schema(
+    subTypes = { // 자식 클래스
+        AuctionLikeListResponse.class,
+        CompletedAuctionLikeListResponse.class,
+        ProcessingAuctionLikeListResponse.class
+    }
+)
+public abstract class BaseAuctionLikeList {
+
+  @Schema(description = "좋아요 ID")
+  private final Long likeId;
+
+  @Schema(description = "경매 상태")
+  private final String status;
+
+  @Schema(description = "경매 id")
+  private final Long auctionId;
+
+  @Schema(description = "경매 제목")
+  private final String title;
+
+  @Schema(description = "경매 이미지 url")
+  private final String auctionImageUrl;
+
+  @Schema(description = "경매 시작가")
+  private final int startPrice;
+
+  @Schema(description = "경매 시작일")
+  private final LocalDate startedAt;
+
+  public BaseAuctionLikeList(Long likeId, String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt) {
+    this.likeId = likeId;
+    this.status = status;
+    this.auctionId = auctionId;
+    this.title = title;
+    this.auctionImageUrl = auctionImageUrl;
+    this.startPrice = startPrice;
+    this.startedAt = startedAt;
+  }
+}

--- a/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/CompletedAuctionLikeListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/CompletedAuctionLikeListResponse.java
@@ -1,0 +1,61 @@
+package com.windfall.api.mypage.dto.auctionlikelist;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "likeId",
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "endPrice",
+    "discountPercent",
+    "startedAt",
+    "tradeStatus"
+})
+public class CompletedAuctionLikeListResponse extends BaseAuctionLikeList{
+  @Schema(description = "하락 퍼센트")
+  private final int discountPercent;
+
+  @Schema(description = "낙찰가")
+  private final int endPrice;
+
+  @Schema(description = "거래 상태")
+  private final String tradeStatus;
+
+  @Builder
+  public CompletedAuctionLikeListResponse(Long likeId, String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt, int discountPercent,
+      int endPrice,
+      String tradeStatus) {
+    super(likeId, status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    this.discountPercent = discountPercent;
+    this.endPrice = endPrice;
+    this.tradeStatus = tradeStatus;
+  }
+
+  public static CompletedAuctionLikeListResponse from(Tuple tuple){
+    return CompletedAuctionLikeListResponse.builder()
+        .likeId(tuple.get("auctionLikeId", Long.class))
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .endPrice(tuple.get("endPrice", Long.class).intValue())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .startedAt(tuple.get("startedAt", Date.class).toLocalDate())
+        .tradeStatus(tuple.get("tradeStatus", String.class))
+        .build();
+  }
+}
+

--- a/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/ProcessingAuctionLikeListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/auctionlikelist/ProcessingAuctionLikeListResponse.java
@@ -1,0 +1,55 @@
+package com.windfall.api.mypage.dto.auctionlikelist;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "likeId",
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "currentPrice",
+    "discountPercent",
+    "startedAt"
+})
+public class ProcessingAuctionLikeListResponse extends BaseAuctionLikeList{
+
+  @Schema(description = "현재가")
+  int currentPrice;
+
+  @Schema(description = "하락 퍼센트")
+  int discountPercent;
+
+  @Builder
+  public ProcessingAuctionLikeListResponse(Long likeId, String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt, int currentPrice,
+      int discountPercent) {
+    super(likeId, status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    this.currentPrice = currentPrice;
+    this.discountPercent = discountPercent;
+  }
+
+  public static ProcessingAuctionLikeListResponse from(Tuple tuple){
+    return ProcessingAuctionLikeListResponse.builder()
+        .likeId(tuple.get("auctionLikeId", Long.class))
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .currentPrice(tuple.get("currentPrice", Long.class).intValue())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .startedAt(tuple.get("startedAt", Date.class).toLocalDate())
+        .build();
+  }
+
+}

--- a/src/main/java/com/windfall/api/mypage/service/AuctionLikeListService.java
+++ b/src/main/java/com/windfall/api/mypage/service/AuctionLikeListService.java
@@ -1,0 +1,113 @@
+package com.windfall.api.mypage.service;
+
+import com.windfall.api.mypage.dto.auctionlikelist.AuctionLikeListRaw;
+import com.windfall.api.mypage.dto.auctionlikelist.AuctionLikeListResponse;
+import com.windfall.api.mypage.dto.auctionlikelist.BaseAuctionLikeList;
+import com.windfall.api.mypage.dto.auctionlikelist.CompletedAuctionLikeListResponse;
+import com.windfall.api.mypage.dto.auctionlikelist.ProcessingAuctionLikeListResponse;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import com.windfall.domain.auction.enums.AuctionStatusGroup;
+import com.windfall.domain.mypage.repository.AuctionLikeListQueryRepository;
+import com.windfall.global.response.SliceResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionLikeListService {
+
+  private final AuctionLikeListQueryRepository auctionLikeListQueryRepository;
+
+  @Transactional
+  public SliceResponse<BaseAuctionLikeList> getMyAuctionLikes(Long userId, AuctionStatus filter, Pageable pageable){
+    //1. RawData 추출
+    Slice<AuctionLikeListRaw> rawData = auctionLikeListQueryRepository.getRawAuctionLikeList(userId, filter, pageable);
+
+    //2. 순서 저장
+    List<Long> dataSequence = rawData.getContent().stream().map(AuctionLikeListRaw::id).toList();
+
+    //3. 그룹화
+    Map<AuctionStatusGroup, List<Long>> groups = groupingData(rawData.getContent());
+
+    //4. 분기 처리
+    Map<Long, BaseAuctionLikeList> resultData = fetchDetailedData(groups, userId);
+
+    //5. 순서대로 재조립
+    List<BaseAuctionLikeList> resultContent = orderByResults(dataSequence, resultData);
+
+    //6. 새로운 slice로 반환
+    Slice<BaseAuctionLikeList> sliceData = toSlice(resultContent, rawData);
+
+    return SliceResponse.from(sliceData);
+  }
+
+  private Map<AuctionStatusGroup, List<Long>> groupingData(List<AuctionLikeListRaw> rawData){
+    Map<AuctionStatusGroup, List<Long>> resultData = new HashMap<>();
+
+    rawData.forEach(raw -> {
+      AuctionStatusGroup key = setGroup(raw.status());
+      resultData.computeIfAbsent(key, k -> new ArrayList<>()).add(raw.id());
+    });
+
+    return resultData;
+  }
+
+  private AuctionStatusGroup setGroup(AuctionStatus status){
+    if(status == AuctionStatus.SCHEDULED || status == AuctionStatus.CANCELED) { //예정, 취소
+      return AuctionStatusGroup.READY_CANCEL;
+    }
+    if(status == AuctionStatus.PROCESS || status == AuctionStatus.FAILED) { //진행 중, 유찰
+      return AuctionStatusGroup.PROCESS_FAILED;
+    }
+    return AuctionStatusGroup.COMPLETED_MY;
+  }
+
+  private Map<Long, BaseAuctionLikeList> fetchDetailedData(Map<AuctionStatusGroup, List<Long>> groups, Long userId){
+    Map<Long, BaseAuctionLikeList> resultData = new HashMap<>();
+
+    if(groups.containsKey(AuctionStatusGroup.READY_CANCEL)){
+      auctionLikeListQueryRepository.getAuctionLikeList(groups.get(AuctionStatusGroup.READY_CANCEL), userId).forEach(
+          data -> {
+            resultData.put(data.get("auctionId", Long.class), AuctionLikeListResponse.from(data));
+          }
+      );
+    }
+    if(groups.containsKey(AuctionStatusGroup.PROCESS_FAILED)){
+      auctionLikeListQueryRepository.getProcessingAuctionLikeList(groups.get(AuctionStatusGroup.PROCESS_FAILED), userId).forEach(
+          data -> {
+            resultData.put(data.get("auctionId", Long.class), ProcessingAuctionLikeListResponse.from(data));
+          }
+      );
+    }
+    if(groups.containsKey(AuctionStatusGroup.COMPLETED_MY)){
+      auctionLikeListQueryRepository.getCompletedAuctionLikeList(groups.get(AuctionStatusGroup.COMPLETED_MY), userId).forEach(
+          data -> {
+            resultData.put(data.get("auctionId", Long.class), CompletedAuctionLikeListResponse.from(data));
+          }
+      );
+    }
+
+    return resultData;
+  }
+
+  private List<BaseAuctionLikeList> orderByResults(List<Long> dataSequence, Map<Long, BaseAuctionLikeList> resultData){
+    return dataSequence.stream().map(resultData::get).toList();
+  }
+
+  private Slice<BaseAuctionLikeList> toSlice(List<BaseAuctionLikeList> resultContent, Slice<?> rawData){
+    return new SliceImpl<>(
+        resultContent,
+        rawData.getPageable(),
+        rawData.hasNext()
+    );
+  }
+
+}

--- a/src/main/java/com/windfall/domain/mypage/repository/AuctionLikeListQueryRepository.java
+++ b/src/main/java/com/windfall/domain/mypage/repository/AuctionLikeListQueryRepository.java
@@ -1,0 +1,101 @@
+package com.windfall.domain.mypage.repository;
+
+import jakarta.persistence.Tuple;
+import com.windfall.api.mypage.dto.auctionlikelist.AuctionLikeListRaw;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
+
+public interface AuctionLikeListQueryRepository extends JpaRepository<Auction, Long> {
+
+  @Query("""
+    SELECT new com.windfall.api.mypage.dto.auctionlikelist.AuctionLikeListRaw(a.id, a.status)
+    FROM AuctionLike al
+    JOIN Auction a ON al.auction.id = a.id
+    WHERE
+    al.userId = :id AND
+    a.status = COALESCE(:filter, a.status) AND
+    al.activated = true
+    ORDER BY a.startedAt DESC
+  """)
+  Slice<AuctionLikeListRaw> getRawAuctionLikeList(@Param("id") Long userId, @Param("filter") AuctionStatus filter, Pageable pageable);
+
+  @Query(value = """
+  SELECT
+  al.id AS auctionLikeId, -- 좋아요 id
+  a.status AS status, -- 경매 상태 (일반, 취소)
+  a.id AS auctionId, -- 경매 아이디
+  a.title AS title, -- 경매 이름 (상품 이름)
+  ai.image AS auctionImageUrl, -- 경매 이미지 url
+  a.start_price AS startPrice, -- 시작가
+  DATE(a.started_at) AS startedAt -- 경매 시작일
+  FROM auction a
+  JOIN auction_like al ON al.auction_id = a.id
+  LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:auctionIds)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+  WHERE a.id IN(:auctionIds) AND al.user_id = :userId;
+""", nativeQuery = true)
+  List<Tuple> getAuctionLikeList(@Param("auctionIds") List<Long> auctionIds, @Param("userId") Long userId);
+
+  @Query(value = """
+  SELECT
+  al.id AS auctionLikeId, -- 좋아요 id
+  a.status AS status, -- 경매 상태 (완료)
+  a.id AS auctionId, -- 경매 아이디
+  a.title AS title, -- 경매 이름 (상품 이름)
+  ai.image AS auctionImageUrl, -- 경매 이미지 url
+  a.start_price AS startPrice, -- 시작가
+  t.final_price AS endPrice, -- 낙찰가
+  ROUND(((a.start_price - t.final_price) / a.start_price) * 100, 0) AS discountPercent, -- 할인율
+  DATE(a.started_at) AS startedAt, -- 경매 시작일
+  t.status AS tradeStatus -- 거래 상태
+  FROM auction a
+  JOIN auction_like al ON al.auction_id = a.id
+  JOIN trade t ON t.auction_id = a.id
+  LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:auctionIds)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+  WHERE a.id IN(:auctionIds) AND al.user_id = :userId;
+  """, nativeQuery = true)
+  List<Tuple> getCompletedAuctionLikeList(@Param("auctionIds") List<Long> auctionIds, @Param("userId") Long userId);
+
+  @Query(value = """
+  SELECT
+  al.id AS auctionLikeId, -- 좋아요 id
+  a.status AS status, -- 경매 상태 (완료)
+  a.id AS auctionId, -- 경매 아이디
+  a.title AS title, -- 경매 이름 (상품 이름)
+  ai.image AS auctionImageUrl, -- 경매 이미지 url
+  a.start_price AS startPrice, -- 시작가
+  a.current_price AS currentPrice, -- 현재가
+  ROUND(((a.start_price - a.current_price) / a.start_price) * 100, 0) AS discountPercent, -- 할인율
+  DATE(a.started_at) AS startedAt -- 경매 시작일
+  FROM auction a
+  JOIN auction_like al ON al.auction_id = a.id
+  LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:auctionIds)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+  WHERE a.id IN(:auctionIds) AND al.user_id = :userId;
+  """, nativeQuery = true)
+  List<Tuple> getProcessingAuctionLikeList(@Param("auctionIds") List<Long> auctionIds, @Param("userId") Long userId);
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #115 

## 📝 변경 사항
### AS-IS
- 찜 목록 조회 API의 부재

### TO-BE
- NativeQuery 기반으로 API 동작
- 서비스, 컨트롤러 로직은 이전 조회 API와 거의 비슷한 구조입니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

### 목록 검색(로그인 유저 기준)
<img width="1477" height="784" alt="image" src="https://github.com/user-attachments/assets/642ab8d2-54d5-438d-97a1-d7c51a98b407" />

<img width="1487" height="785" alt="image" src="https://github.com/user-attachments/assets/ac8b1130-8d36-43cc-9ec5-c6d7b0a12a3f" />

### 필터링 검색
<img width="1492" height="728" alt="image" src="https://github.com/user-attachments/assets/1604cf34-051b-4208-9aa8-eab303936902" />

### DB와 결과가 일치한지 검증
<img width="1357" height="806" alt="image" src="https://github.com/user-attachments/assets/dc0fe361-845f-4ce5-8948-08f6ad112b72" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
서비스, 컨트롤러 로직은 거의 똑같습니다. 
로직이 중복이라고 생각이 되겠지만 각각 다른 기능을 수행하기 때문에 중복이더라도 확장성을 위해 따로 분리하는게 좋다고 생각하여 현재는 서비스 로직을 분리한 상태입니다.
NavtiveQuery가 조금 다르니 잘 봐주시면 감사하겠습니다