### PR TITLE
[Feature] 알림 SSE, 가격 하락 이벤트

### DIFF
--- a/src/main/java/com/windfall/api/auction/controller/AuctionController.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionController.java
@@ -131,8 +131,9 @@ public class AuctionController implements AuctionSpecification {
   public ApiResponse<AuctionCancelResponse> cancelAuction(
       @PathVariable Long auctionId,
 
-      @RequestParam Long userId
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
+    Long userId = userDetails.getUserId();
     AuctionCancelResponse response = auctionService.cancelAuction(auctionId, userId);
     return ApiResponse.ok("경매가 취소되었습니다.", response);
   }
@@ -142,9 +143,9 @@ public class AuctionController implements AuctionSpecification {
   public ApiResponse<Void> deleteAuction(
       @PathVariable Long auctionId,
 
-      // TODO 임시 유저 id -> 로그인 개발 시 제거해야 함
-      @RequestParam Long userId
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
+    Long userId = userDetails.getUserId();
     auctionService.deleteAuction(auctionId, userId);
     return ApiResponse.noContent();
   }

--- a/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
@@ -142,7 +142,7 @@ public interface AuctionSpecification {
       @PathVariable Long auctionId,
 
       @Parameter(description = "사용자 ID", required = true, example = "1")
-      @RequestParam Long userId
+      @AuthenticationPrincipal CustomUserDetails userDetails
   );
 
   @ApiErrorCodes({NOT_FOUND_AUCTION, NOT_FOUND_USER, AUCTION_CANNOT_DELETE, INVALID_AUCTION_SELLER,
@@ -153,6 +153,6 @@ public interface AuctionSpecification {
       @PathVariable Long auctionId,
 
       @Parameter(description = "사용자 ID", required = true, example = "1")
-      @RequestParam Long userId
+      @AuthenticationPrincipal CustomUserDetails userDetails
   );
 }

--- a/src/main/java/com/windfall/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationController.java
@@ -66,9 +66,10 @@ public class NotificationController implements NotificationSpecification{
   @Override
   @GetMapping(value = "/subscribe", produces = "text/event-stream")
   public SseEmitter subscribe(
-      @AuthenticationPrincipal Long id,
+      @AuthenticationPrincipal CustomUserDetails user,
       @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId
   ){
+    Long id = user.getUserId();
     return sseService.subscribe(id,lastEventId);
   }
 

--- a/src/main/java/com/windfall/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationController.java
@@ -64,9 +64,9 @@ public class NotificationController implements NotificationSpecification{
   }
 
   @Override
-  @GetMapping(value = "/subscribe/{id}", produces = "text/event-stream")
+  @GetMapping(value = "/subscribe", produces = "text/event-stream")
   public SseEmitter subscribe(
-      @PathVariable Long id,
+      @AuthenticationPrincipal Long id,
       @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId
   ){
     return sseService.subscribe(id,lastEventId);

--- a/src/main/java/com/windfall/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationController.java
@@ -4,6 +4,7 @@ import com.windfall.api.notification.dto.response.NotificationMarkAllResponse;
 import com.windfall.api.notification.dto.response.NotificationMarkResponse;
 import com.windfall.api.notification.dto.response.NotificationReadResponse;
 import com.windfall.api.notification.service.NotificationService;
+import com.windfall.api.notification.service.SseService;
 import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import com.windfall.global.response.SliceResponse;
@@ -16,9 +17,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/v1/notifications")
@@ -26,6 +29,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController implements NotificationSpecification{
 
   private final NotificationService notificationService;
+
+  private final SseService sseService;
 
   @Override
   @GetMapping
@@ -57,4 +62,14 @@ public class NotificationController implements NotificationSpecification{
     NotificationMarkAllResponse response = notificationService.markAllAsRead(user);
     return ApiResponse.ok("알림이 모두 읽음 처리되었습니다.",response);
   }
+
+  @Override
+  @GetMapping(value = "/subscribe/{id}", produces = "text/event-stream")
+  public SseEmitter subscribe(
+      @PathVariable Long id,
+      @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId
+  ){
+    return sseService.subscribe(id,lastEventId);
+  }
+
 }

--- a/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
@@ -47,7 +47,7 @@ public interface NotificationSpecification {
 
   @Operation(summary = "실시간 알림 처리", description = "SSE를 이용해서 실시간 알림 처리를 합니다..")
   SseEmitter subscribe(
-      @PathVariable Long id,
+      @AuthenticationPrincipal Long id,
       @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId
   );
 

--- a/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
@@ -47,7 +47,7 @@ public interface NotificationSpecification {
 
   @Operation(summary = "실시간 알림 처리", description = "SSE를 이용해서 실시간 알림 처리를 합니다..")
   SseEmitter subscribe(
-      @AuthenticationPrincipal Long id,
+      @AuthenticationPrincipal CustomUserDetails user,
       @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId
   );
 

--- a/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
+++ b/src/main/java/com/windfall/api/notification/controller/NotificationSpecification.java
@@ -15,7 +15,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Tag(name = "Notification", description = "알림 API")
 public interface NotificationSpecification {
@@ -42,4 +44,11 @@ public interface NotificationSpecification {
   ApiResponse<NotificationMarkAllResponse> markAllAsRead(
       @AuthenticationPrincipal CustomUserDetails user
   );
+
+  @Operation(summary = "실시간 알림 처리", description = "SSE를 이용해서 실시간 알림 처리를 합니다..")
+  SseEmitter subscribe(
+      @PathVariable Long id,
+      @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId
+  );
+
 }

--- a/src/main/java/com/windfall/api/notification/event/PriceAlertEventListener.java
+++ b/src/main/java/com/windfall/api/notification/event/PriceAlertEventListener.java
@@ -1,0 +1,41 @@
+package com.windfall.api.notification.event;
+
+import com.windfall.api.notification.event.vo.AuctionPriceDroppedEvent;
+import com.windfall.api.notification.service.SseService;
+import com.windfall.domain.notification.entity.PriceNotification;
+import com.windfall.domain.notification.repository.PriceNotificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PriceAlertEventListener {
+
+  private final PriceNotificationRepository priceNotificationRepository;
+  private final SseService sseService;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void sendPriceAlert(AuctionPriceDroppedEvent event) {
+    List<PriceNotification> alerts =
+        priceNotificationRepository.findNotNotified(
+            event.auctionId(),
+            event.currentPrice()
+        );
+
+    for (PriceNotification alert : alerts) {
+      if (event.previousPrice() > alert.getTargetPrice()
+          && event.currentPrice() <= alert.getTargetPrice()) {
+        sseService.priceNotificationSend(
+            alert.getUserId(),
+            alert.getAuctionId(),
+            String.valueOf(alert.getTargetPrice())
+        );
+      }
+    }
+  }
+}

--- a/src/main/java/com/windfall/api/notification/event/vo/AuctionPriceDroppedEvent.java
+++ b/src/main/java/com/windfall/api/notification/event/vo/AuctionPriceDroppedEvent.java
@@ -1,0 +1,10 @@
+package com.windfall.api.notification.event.vo;
+
+import java.time.LocalDateTime;
+
+public record AuctionPriceDroppedEvent(
+    Long auctionId,
+    Long previousPrice,
+    Long currentPrice,
+    LocalDateTime droppedAt
+) {}

--- a/src/main/java/com/windfall/api/notification/service/SseService.java
+++ b/src/main/java/com/windfall/api/notification/service/SseService.java
@@ -1,5 +1,6 @@
 package com.windfall.api.notification.service;
 
+import com.windfall.api.notification.dto.response.NotificationReadResponse;
 import com.windfall.domain.notification.entity.Notification;
 import com.windfall.domain.notification.enums.NotificationType;
 import com.windfall.domain.notification.repository.NotificationRepository;
@@ -10,6 +11,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -63,7 +65,8 @@ public class SseService {
       sseEmitterMap.remove(id);
     }
   }
-  @Transactional
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void priceNotificationSend(Long userId,Long targetId,String content) {
     User user = userRepository.findById(userId).orElse(null);
     Notification notification = Notification.create(user,
@@ -72,9 +75,10 @@ public class SseService {
         false,
         NotificationType.PRICE_DROP,targetId);
     Notification saveNotification = notificationRepository.save(notification);
+    NotificationReadResponse response = NotificationReadResponse.from(saveNotification);
     String id = String.valueOf(userId);
 
 
-    sendToClient(id, "priceAlert", saveNotification);
+    sendToClient(id, "priceAlert", response);
   }
 }

--- a/src/main/java/com/windfall/api/notification/service/SseService.java
+++ b/src/main/java/com/windfall/api/notification/service/SseService.java
@@ -1,0 +1,80 @@
+package com.windfall.api.notification.service;
+
+import com.windfall.domain.notification.entity.Notification;
+import com.windfall.domain.notification.enums.NotificationType;
+import com.windfall.domain.notification.repository.NotificationRepository;
+import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.repository.UserRepository;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+public class SseService {
+  private final Map<String, SseEmitter> sseEmitterMap = new ConcurrentHashMap<>();
+  private final UserRepository userRepository;
+  private final NotificationRepository notificationRepository;
+
+
+  // TODO 현재 lastEventId 처리는 구현하지 않음 -> 나중에 userId가 아닌 따로 관리할 때 구현 예정 + SSE 관련 캐싱이나 DB 저장도 고려
+  public SseEmitter subscribe(Long userId,String lastEventId) {
+    long timeout = 1000L * 60 * 60;
+    String id = String.valueOf(userId);
+
+    SseEmitter sseEmitter = new SseEmitter(timeout);
+    sseEmitterMap.put(String.valueOf(id), sseEmitter);
+
+
+    sseEmitter.onCompletion(() -> sseEmitterMap.remove(id));
+
+    sseEmitter.onTimeout(sseEmitter::complete);
+
+    sseEmitter.onError(throwable -> sseEmitter.complete());
+
+
+    sendToClient(id, "","EventStream Created. [userId= %s]".formatted(userId));
+
+    return sseEmitter;
+  }
+
+
+  public void sendToClient(String id, String eventName,  Object data) {
+    SseEmitter sseEmitter = sseEmitterMap.get(id);
+
+    if (sseEmitter == null) {
+      return;
+    }
+
+    try {
+      sseEmitter.send(
+          SseEmitter
+              .event()
+              .id(id)
+              .name(eventName)
+              .data(data)
+      );
+    } catch (IOException e) {
+      sseEmitter.complete();
+      sseEmitterMap.remove(id);
+    }
+  }
+  @Transactional
+  public void priceNotificationSend(Long userId,Long targetId,String content) {
+    User user = userRepository.findById(userId).orElse(null);
+    Notification notification = Notification.create(user,
+        "가격 하락 알림",
+        "관심 상품의 가격이 하락했습니다: " + content,
+        false,
+        NotificationType.PRICE_DROP,targetId);
+    Notification saveNotification = notificationRepository.save(notification);
+    String id = String.valueOf(userId);
+
+
+    sendToClient(id, "priceAlert", saveNotification);
+  }
+}

--- a/src/main/java/com/windfall/domain/notification/entity/PriceNotification.java
+++ b/src/main/java/com/windfall/domain/notification/entity/PriceNotification.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,10 +20,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PriceNotification extends BaseEntity {
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(nullable = false)
   private NotificationSetting setting;
 
-  @Column(nullable = false)
-  private Long priceAlert;
+  private Long auctionId;  // join 회피 용
+
+  private Long userId;  // join 회피 용
+
+  private Long targetPrice;
+
+  private Boolean notified;
 }

--- a/src/main/java/com/windfall/domain/notification/repository/PriceNotificationRepository.java
+++ b/src/main/java/com/windfall/domain/notification/repository/PriceNotificationRepository.java
@@ -1,7 +1,20 @@
 package com.windfall.domain.notification.repository;
 
 import com.windfall.domain.notification.entity.PriceNotification;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PriceNotificationRepository extends JpaRepository<PriceNotification,Long> {
+  @Query("""
+select a from PriceNotification a
+where a.auctionId = :auctionId
+  and a.targetPrice >= :currentPrice
+  and a.notified = false
+""")
+  List<PriceNotification> findNotNotified(
+      @Param("auctionId") Long auctionId,
+      @Param("currentPrice") Long currentPrice
+  );
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #118

## 📝 변경 사항
### AS-IS
- 기존 코드의 동작 방식 설명
- 기존의 문제점 설명

### TO-BE
- 알림 SSE 구현 완료
  - SSE로 실시간 알림 받아오기 
- 가격 하락 이벤트 구현 
  - 설정된 가격 구간이 될 경우 캐칭을 하는 구조
  - 비동기 구현 및 이벤트 리스너
## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="527" height="874" alt="image" src="https://github.com/user-attachments/assets/f84f3de8-3f0e-4e54-bbec-75378f62f8e4" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 필수 구현 파트여서 급하게 작성한 내용인 점 양해 부탁드립니다.
- SSE 연결 시간은 1시간으로 설정했습니다.
- 휴가 일정때문에 완성도가 낮은 코드가 된 것 같네여.. 추후에 수정될 수도 있습니다.