### PR TITLE
[Feature] WebSocket STOMP 인프라 개선: 개인 큐 지원 + CONNECT 인증(Principal) 세팅 추가

### DIFF
--- a/src/main/java/com/windfall/api/user/service/JwtProvider.java
+++ b/src/main/java/com/windfall/api/user/service/JwtProvider.java
@@ -120,4 +120,18 @@ public class JwtProvider {
     refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60); // 7일 (일주일)
     return refreshTokenCookie;
   }
+
+  public Long getUserId(String token) {
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+
+    Object v = claims.get("userId");
+    if (v == null) return null;
+    if (v instanceof Integer i) return i.longValue();
+    if (v instanceof Long l) return l;
+    return Long.valueOf(String.valueOf(v));
+  }
 }

--- a/src/main/java/com/windfall/global/config/WebSocketConfig.java
+++ b/src/main/java/com/windfall/global/config/WebSocketConfig.java
@@ -1,8 +1,7 @@
 package com.windfall.global.config;
 
-import java.util.Arrays;
+import com.windfall.global.websocket.StompAuthChannelInterceptor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -17,9 +16,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
 
-  @Value("${custom.cors.allowed-origins:*}")
-  private String allowedOrigins;
-
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {
     config.enableSimpleBroker("/topic", "/queue");
@@ -29,13 +25,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
-    String[] origins = Arrays.stream(allowedOrigins.split(","))
-        .map(String::trim)
-        .filter(s -> !s.isBlank())
-        .toArray(String[]::new);
-
     registry.addEndpoint("/ws-stomp")
-        .setAllowedOriginPatterns(origins.length == 0 ? new String[]{"*"} : origins)
+        .setAllowedOriginPatterns("*")
         .withSockJS();
   }
 

--- a/src/main/java/com/windfall/global/config/WebSocketConfig.java
+++ b/src/main/java/com/windfall/global/config/WebSocketConfig.java
@@ -1,6 +1,10 @@
 package com.windfall.global.config;
 
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,18 +12,35 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+  @Value("${custom.cors.allowed-origins:*}")
+  private String allowedOrigins;
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {
-    config.enableSimpleBroker("/topic");
+    config.enableSimpleBroker("/topic", "/queue");
     config.setApplicationDestinationPrefixes("/app");
+    config.setUserDestinationPrefix("/user");
   }
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
+    String[] origins = Arrays.stream(allowedOrigins.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .toArray(String[]::new);
+
     registry.addEndpoint("/ws-stomp")
-        .setAllowedOriginPatterns("*")
+        .setAllowedOriginPatterns(origins.length == 0 ? new String[]{"*"} : origins)
         .withSockJS();
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(stompAuthChannelInterceptor);
   }
 }

--- a/src/main/java/com/windfall/global/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/windfall/global/websocket/StompAuthChannelInterceptor.java
@@ -1,0 +1,68 @@
+package com.windfall.global.websocket;
+
+import com.windfall.api.user.service.JwtProvider;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+  private static final Long DEV_USER_ID = 1L;
+
+  private final JwtProvider jwtProvider;
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+    if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+
+      String auth = accessor.getFirstNativeHeader("Authorization");
+      String token = extractBearer(auth);
+
+      // 토큰이 없으면:하드코딩 Principal
+      if (token == null) {
+        accessor.setUser(new StompPrincipal(DEV_USER_ID));
+        return message;
+      }
+
+      // 토큰이 있으면: 검증 후 userId 기반 Principal 세팅(추후 인증 전환 대비)
+      if (!jwtProvider.validateToken(token)) {
+        throw new ErrorException(ErrorCode.INVALID_TOKEN);
+      }
+
+      Long userId = jwtProvider.getUserId(token);
+      if (userId == null) {
+        throw new ErrorException(ErrorCode.INVALID_TOKEN);
+      }
+
+      accessor.setUser(new StompPrincipal(userId));
+    }
+
+    if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+      Principal user = accessor.getUser();
+      if (user != null) {
+        // log.info("WS DISCONNECT userId={}", user.getName());
+      }
+    }
+
+    return message;
+  }
+
+  private String extractBearer(String authHeader) {
+    if (authHeader == null) return null;
+    if (authHeader.startsWith("Bearer ")) return authHeader.substring(7);
+    return null;
+  }
+}
+

--- a/src/main/java/com/windfall/global/websocket/StompPrincipal.java
+++ b/src/main/java/com/windfall/global/websocket/StompPrincipal.java
@@ -1,0 +1,9 @@
+package com.windfall.global.websocket;
+
+import java.security.Principal;
+
+public class StompPrincipal implements Principal {
+  private final String name;
+  public StompPrincipal(Long userId) { this.name = String.valueOf(userId); }
+  @Override public String getName() { return name; }
+}

--- a/src/main/java/com/windfall/global/websocket/StompPrincipal.java
+++ b/src/main/java/com/windfall/global/websocket/StompPrincipal.java
@@ -4,6 +4,11 @@ import java.security.Principal;
 
 public class StompPrincipal implements Principal {
   private final String name;
-  public StompPrincipal(Long userId) { this.name = String.valueOf(userId); }
-  @Override public String getName() { return name; }
+
+  public StompPrincipal(Long userId) {
+    this.name = String.valueOf(userId);
+  }
+  @Override public String getName() {
+    return name;
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #125 

## 📝 변경 사항
### AS-IS
* WebSocket 설정에서 `/topic`만 브로커로 사용하여 `/user/queue` 기반 개인 큐 메시징이 불가능했음
* STOMP 연결 시 사용자 인증/식별(Principal) 설정이 없어,

  * 이후 `convertAndSendToUser` 기반 목록 실시간 갱신을 구현하기 어려움
  * 메시지 전송 시 senderId를 클라이언트에 의존할 가능성이 있어 보안/정합성 리스크가 존재함

### TO-BE
* WebSocket broker 설정 개선

  * `/topic`, `/queue` 브로커 활성화
  * `setUserDestinationPrefix("/user")` 추가로 개인 큐(`/user/queue/**`) 사용 가능
* STOMP CONNECT 단계 인증/식별 로직 추가

  * `ChannelInterceptor`에서 CONNECT 프레임의 Authorization(Bearer) 토큰을 파싱
  * 토큰 검증 성공 시 JWT claim의 userId를 기반으로 Principal 세팅
  * 개발 환경에서는 토큰이 없을 때 userId=1L 하드코딩으로 연결 테스트 가능(추후 운영 전환 대비)
* `StompPrincipal` 추가

  * Principal의 name을 userId 문자열로 맞춰 `convertAndSendToUser` 라우팅 기준을 통일
* `JwtProvider#getUserId` 추가

  * 토큰 claim에서 userId 추출 지원으로 STOMP 인증 흐름과 연동

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
  * 추후 소셜 로그인 연동 완료 시, 토큰 기반 인증만 허용하도록 전환 예정입니다(운영 환경에서는 토큰 필수화 예정).
  - 추후 웹소켓 연결을 원활하게 하기 위한 인프라 개선 pr입니다. 바로 다음 pr에서 채팅 웹소켓 모두 연결 예정입니다.

