### PR TITLE
[Feature] 액세스토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/com/windfall/api/payment/dto/request/PaymentConfirmRequest.java
+++ b/src/main/java/com/windfall/api/payment/dto/request/PaymentConfirmRequest.java
@@ -7,3 +7,15 @@ public record PaymentConfirmRequest(
     String paymentProvider,
     String paymentMethod
 ){}
+
+/*
+*
+* // 이거로 변경하자.
+public record PaymentConfirmRequest(
+    String paymentKey,
+    String orderId,
+    Long amount,
+    String auctionId
+){}
+* orderId는 사용자별 고유한 값으로 설정해놨습니당 uuid 만들어서 보내도록 설정해놨어요!
+* */

--- a/src/main/java/com/windfall/api/payment/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/com/windfall/api/payment/dto/response/PaymentConfirmResponse.java
@@ -21,3 +21,5 @@ public class PaymentConfirmResponse {
     this.status = status;
   }
 }
+// status, amount, orderId 만 넣자.
+// orderId를 UUID로 보내주신 만큼, 반환도 UUID로 반환하자

--- a/src/main/java/com/windfall/api/user/controller/UserController.java
+++ b/src/main/java/com/windfall/api/user/controller/UserController.java
@@ -12,18 +12,15 @@
 package com.windfall.api.user.controller;
 
 import com.windfall.api.user.dto.response.LoginUserResponse;
+import com.windfall.api.user.dto.response.OAuthTokenResponse;
 import com.windfall.api.user.service.JwtProvider;
 import com.windfall.api.user.service.UserService;
 import com.windfall.domain.user.entity.User;
-import com.windfall.domain.user.enums.ProviderType;
-import com.windfall.global.exception.ErrorCode;
-import com.windfall.global.exception.ErrorException;
 import com.windfall.global.response.ApiResponse;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -120,28 +117,11 @@ public class UserController implements UserSpecification {
   }
 
   @PostMapping("/auth/regenerate-access-token")
-  public ApiResponse<Void> regenerateAccessToken(
+  public ApiResponse<OAuthTokenResponse> regenerateAccessToken(
       HttpServletRequest request, HttpServletResponse response) {
-    // 1. 쿠키에서 리프레시 토큰 추출
-    String refreshToken = Arrays.stream(request.getCookies())
-        .filter(c -> "refreshToken".equals(c.getName()))
-        .findFirst()
-        .map(Cookie::getValue)
-        .orElseThrow(() -> new ErrorException(ErrorCode.EMPTY_REFRESH_TOKEN));
 
-    // 2. DB에서 유저 확인
-    //User user = userRepository.findByRefreshToken(refreshToken)
-    //    .orElseThrow(() -> new ErrorException(ErrorCode.INVALID_REFRESH_TOKEN));
-    User user = new User(ProviderType.KAKAO, "1", "", "", "");
-
-    // 3. 액세스 토큰 발급
-    String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getProviderUserId());
-
-    // 4. 쿠키로 반환
-    Cookie accessTokenCookie = generateCookieWithAccessToken(newAccessToken);
-    response.addCookie(accessTokenCookie);
-
-    return ApiResponse.ok("액세스 토큰 재발급 완료", null);
+    OAuthTokenResponse oAuthTokenResponse = userService.regenerateAccessToken(request);
+    return ApiResponse.ok("액세스 토큰 재발급 완료", oAuthTokenResponse);
   }
 
 

--- a/src/main/java/com/windfall/api/user/controller/UserController.java
+++ b/src/main/java/com/windfall/api/user/controller/UserController.java
@@ -20,7 +20,6 @@ import com.windfall.global.response.ApiResponse;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -117,8 +116,7 @@ public class UserController implements UserSpecification {
   }
 
   @PostMapping("/auth/regenerate-access-token")
-  public ApiResponse<OAuthTokenResponse> regenerateAccessToken(
-      HttpServletRequest request, HttpServletResponse response) {
+  public ApiResponse<OAuthTokenResponse> regenerateAccessToken(HttpServletRequest request) {
 
     OAuthTokenResponse oAuthTokenResponse = userService.regenerateAccessToken(request);
     return ApiResponse.ok("액세스 토큰 재발급 완료", oAuthTokenResponse);

--- a/src/main/java/com/windfall/api/user/controller/UserSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/UserSpecification.java
@@ -4,9 +4,12 @@
 package com.windfall.api.user.controller;
 
 import com.windfall.api.user.dto.response.LoginUserResponse;
+import com.windfall.api.user.dto.response.OAuthTokenResponse;
 import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -21,4 +24,7 @@ public interface UserSpecification {
 
   @Operation(summary = "두 토큰 중 하나라도 사용 가능한가 true/false 반환", description = "쿠키 속 액세스 토큰과 리프레시 토큰 중 하나라도 사용 가능하면 true, 둘 다 만료되었으면 false 반환합니다.")
   public ApiResponse<Boolean> validateTokens(@CookieValue("accessToken") String accessToken, @CookieValue("refreshToken") String refreshToken);
+
+  @Operation(summary = "액세스토큰 재발급", description = "로그인 반환양식과 동일하게 userId, accessToken, refreshToken으로 반환합니다.")
+  public ApiResponse<OAuthTokenResponse> regenerateAccessToken(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/windfall/api/user/controller/UserSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/UserSpecification.java
@@ -9,7 +9,6 @@ import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -26,5 +25,5 @@ public interface UserSpecification {
   public ApiResponse<Boolean> validateTokens(@CookieValue("accessToken") String accessToken, @CookieValue("refreshToken") String refreshToken);
 
   @Operation(summary = "액세스토큰 재발급", description = "로그인 반환양식과 동일하게 userId, accessToken, refreshToken으로 반환합니다.")
-  public ApiResponse<OAuthTokenResponse> regenerateAccessToken(HttpServletRequest request, HttpServletResponse response);
+  public ApiResponse<OAuthTokenResponse> regenerateAccessToken(HttpServletRequest request);
 }

--- a/src/main/java/com/windfall/api/user/service/JwtProvider.java
+++ b/src/main/java/com/windfall/api/user/service/JwtProvider.java
@@ -3,6 +3,7 @@ package com.windfall.api.user.service;
 import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class JwtProvider {
+
   private final Key key; // SecretKey로 변환
   private final long accessTokenValidity;
   private final long refreshTokenValidity;
@@ -119,5 +121,24 @@ public class JwtProvider {
     refreshTokenCookie.setPath("/");
     refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60); // 7일 (일주일)
     return refreshTokenCookie;
+  }
+
+  public Long extractUserId(String token) {
+    // refreshToken이 만료되면 내부 값이 추출할 수 없다.
+    try {
+      Claims claims = Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(token)
+          .getBody();
+
+      return claims.get("userId", Long.class);
+
+    } catch (ExpiredJwtException e) {
+      throw new ErrorException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+
+    } catch (JwtException | IllegalArgumentException e) {
+      throw new ErrorException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
   }
 }

--- a/src/main/java/com/windfall/api/user/service/UserService.java
+++ b/src/main/java/com/windfall/api/user/service/UserService.java
@@ -1,10 +1,15 @@
 package com.windfall.api.user.service;
 
+import com.windfall.api.user.dto.response.OAuthTokenResponse;
 import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.entity.UserToken;
 import com.windfall.domain.user.repository.UserRepository;
+import com.windfall.domain.user.repository.UserTokenRepository;
 import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final UserTokenRepository userTokenRepository;
+  private final JwtProvider jwtProvider;
 
   @Transactional(readOnly = true)
   public User getUserById(Long userId) {
@@ -31,9 +38,35 @@ public class UserService {
 
   @Transactional(readOnly = true)
   public Map<Long, User> getUsersMapByIds(Set<Long> userIds) {
-    if (userIds == null || userIds.isEmpty()) return Map.of();
+    if (userIds == null || userIds.isEmpty()) {
+      return Map.of();
+    }
 
     return userRepository.findAllById(userIds).stream()
         .collect(Collectors.toMap(User::getId, u -> u));
+  }
+
+  @Transactional
+  public OAuthTokenResponse regenerateAccessToken(HttpServletRequest request) {
+
+    String refreshToken = jwtProvider.extractRefreshTokenFromCookie(request);
+    Long userId = jwtProvider.extractUserId(refreshToken);
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_USER));
+    UserToken userToken = userTokenRepository.findByUser(user)
+        .orElseThrow(() -> new ErrorException(ErrorCode.INVALID_REFRESH_TOKEN));
+    String userRefreshToken = userToken.getRefreshToken();
+
+    // Null Point Exception 방어를 위해 .equals 대신 Objects.equals() 사용
+    if(!Objects.equals(refreshToken, userRefreshToken)){
+      throw new ErrorException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    String newRefreshToken = jwtProvider.generateRefreshToken(userId, user.getProviderUserId());
+    userToken.saveRefreshToken(newRefreshToken);
+
+    String newAccessToken = jwtProvider.generateAccessToken(userId, user.getProviderUserId());
+
+    return new OAuthTokenResponse(userId, newAccessToken, newRefreshToken);
   }
 }

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
   NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "해당 provider를 찾을 수 없습니다."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "올바른 토큰 값이 아닙니다."),
   EMPTY_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "쿠키에 리프레시 토큰이 없습니다."),
+  EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
+  INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 못한 리프레시 토큰입니다."),
 
   // 경매
   INVALID_TIME(HttpStatus.BAD_REQUEST, "경매 시간을 다시 설정해주세요."),


### PR DESCRIPTION
## 📌 관련 이슈
- close #120

## 📝 변경 사항
### AS-IS
- 액세스토큰 만료 시 리프레시토큰으로 재발급하지 않고 있었습니다.

### TO-BE
- 리프레시 토큰 먼저 체크 후, 멀쩡하면 액세스토큰을 새로 만들어 반환합니다.
- 서버사이드렌더링이라 쿠키 대신 DTO로 userId, accessToken, refreshToken 세개 전달합니다.

- payment DTO는 다음 issue 때 쓸 주석이 달린 정도의 변경 사항입니다.
- 다음 issue 때 구현하고 지우겠습니다.

## 🔍 테스트
- 웹 브라우저와 함께 테스트해야하는데, 현재 컨트롤러와 기능연결이 안되어있어 테스트가 어렵습니다.
- 일단 gpt에 검수 받고, 프론트 팀원분이 기능연결하신 이후에 같이 테스트해서 에러가 있다면 고치는 방식으로 진행하겠습니다.
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
