### PR TITLE
[Feature] 최근 본 목록 API 구현

### DIFF
--- a/src/main/java/com/windfall/api/mypage/controller/MyPageController.java
+++ b/src/main/java/com/windfall/api/mypage/controller/MyPageController.java
@@ -4,9 +4,11 @@ import com.windfall.api.mypage.dto.auctionlikelist.AuctionLikeListResponse;
 import com.windfall.api.mypage.dto.auctionlikelist.BaseAuctionLikeList;
 import com.windfall.api.mypage.dto.notificationsetlist.BaseNotificationSetList;
 import com.windfall.api.mypage.dto.purchasehistory.BasePurchaseHistory;
+import com.windfall.api.mypage.dto.recentviewlist.BaseRecentViewList;
 import com.windfall.api.mypage.service.AuctionLikeListService;
 import com.windfall.api.mypage.service.NotificationSetListService;
 import com.windfall.api.mypage.service.PurchaseHistoryService;
+import com.windfall.api.mypage.service.RecentViewListService;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
@@ -29,6 +31,7 @@ public class MyPageController implements MyPageSpecification{
   private final PurchaseHistoryService purchaseHistoryService;
   private final NotificationSetListService notificationSetListService;
   private final AuctionLikeListService auctionLikeListService;
+  private final RecentViewListService recentViewListService;
 
   @GetMapping("/purchases")
   public ApiResponse<SliceResponse<BasePurchaseHistory>> getMyPurchaseHistory(
@@ -66,5 +69,18 @@ public class MyPageController implements MyPageSpecification{
     SliceResponse<BaseAuctionLikeList> response = auctionLikeListService.getMyAuctionLikes(userId, filter, pageable);
 
     return ApiResponse.ok("찜 목록 조회에 성공하였습니다.", response);
+  }
+
+  @Override
+  @GetMapping("/recentviews")
+  public ApiResponse<SliceResponse<BaseRecentViewList>> getMyRecentViews(
+      @PageableDefault(page = 0, size = 10) Pageable pageable,
+      @RequestParam(required = false) AuctionStatus filter,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    Long userId = userDetails.getUserId();
+    SliceResponse<BaseRecentViewList> response = recentViewListService.getMyRecentViewLists(userId, filter, pageable);
+
+    return ApiResponse.ok("최근 본 경매 내역 조회에 성공하였습니다.", response);
   }
 }

--- a/src/main/java/com/windfall/api/mypage/controller/MyPageSpecification.java
+++ b/src/main/java/com/windfall/api/mypage/controller/MyPageSpecification.java
@@ -3,6 +3,7 @@ package com.windfall.api.mypage.controller;
 import com.windfall.api.mypage.dto.auctionlikelist.BaseAuctionLikeList;
 import com.windfall.api.mypage.dto.notificationsetlist.BaseNotificationSetList;
 import com.windfall.api.mypage.dto.purchasehistory.BasePurchaseHistory;
+import com.windfall.api.mypage.dto.recentviewlist.BaseRecentViewList;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.notification.enums.NotificationType;
 import com.windfall.domain.user.entity.CustomUserDetails;
@@ -32,6 +33,12 @@ public interface MyPageSpecification {
 
   @Operation(summary = "나의 찜 목록 조회", description = "자신이 찜한 경매 목록을 조회합니다.")
   ApiResponse<SliceResponse<BaseAuctionLikeList>> getMyAuctionLikes(@PageableDefault(page = 0, size = 10) Pageable pageable,
+      @RequestParam(required = false) AuctionStatus filter,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  );
+
+  @Operation(summary = "나의 최근 본 내역 조회", description = "자신이 최근에 본 경매 목록을 조회합니다.")
+  ApiResponse<SliceResponse<BaseRecentViewList>> getMyRecentViews(@PageableDefault(page = 0, size = 10) Pageable pageable,
       @RequestParam(required = false) AuctionStatus filter,
       @AuthenticationPrincipal CustomUserDetails userDetails
   );

--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/BaseRecentViewList.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/BaseRecentViewList.java
@@ -1,0 +1,44 @@
+package com.windfall.api.mypage.dto.recentviewlist;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+@Schema(
+    subTypes = { // 자식 클래스
+        RecentViewListResponse.class,
+        CompletedRecentViewListResponse.class,
+        ProcessingRecentViewListResponse.class
+    }
+)
+public abstract class BaseRecentViewList {
+
+  @Schema(description = "경매 상태")
+  private final String status;
+
+  @Schema(description = "경매 id")
+  private final Long auctionId;
+
+  @Schema(description = "경매 제목")
+  private final String title;
+
+  @Schema(description = "경매 이미지 url")
+  private final String auctionImageUrl;
+
+  @Schema(description = "경매 시작가")
+  private final int startPrice;
+
+  @Schema(description = "경매 시작일")
+  private final LocalDate startedAt;
+
+  public BaseRecentViewList(String status, Long auctionId, String title, String auctionImageUrl,
+      int startPrice, LocalDate startedAt) {
+    this.status = status;
+    this.auctionId = auctionId;
+    this.title = title;
+    this.auctionImageUrl = auctionImageUrl;
+    this.startPrice = startPrice;
+    this.startedAt = startedAt;
+  }
+}

--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/CompletedRecentViewListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/CompletedRecentViewListResponse.java
@@ -1,0 +1,57 @@
+package com.windfall.api.mypage.dto.recentviewlist;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "endPrice",
+    "discountPercent",
+    "startedAt",
+    "tradeStatus"
+})
+public class CompletedRecentViewListResponse extends BaseRecentViewList{
+  @Schema(description = "하락 퍼센트")
+  private final int discountPercent;
+
+  @Schema(description = "낙찰가")
+  private final int endPrice;
+
+  @Schema(description = "거래 상태")
+  private final String tradeStatus;
+
+  @Builder
+  public CompletedRecentViewListResponse(String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt, int discountPercent,
+      int endPrice, String tradeStatus) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    this.discountPercent = discountPercent;
+    this.endPrice = endPrice;
+    this.tradeStatus = tradeStatus;
+  }
+
+  public static CompletedRecentViewListResponse from(Tuple tuple){
+    return CompletedRecentViewListResponse.builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .endPrice(tuple.get("endPrice", Long.class).intValue())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .startedAt(tuple.get("startedAt", Date.class).toLocalDate())
+        .tradeStatus(tuple.get("tradeStatus", String.class))
+        .build();
+  }
+}

--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/ProcessingRecentViewListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/ProcessingRecentViewListResponse.java
@@ -1,0 +1,52 @@
+package com.windfall.api.mypage.dto.recentviewlist;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Tuple;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "currentPrice",
+    "discountPercent",
+    "startedAt"
+})
+public class ProcessingRecentViewListResponse extends BaseRecentViewList{
+  @Schema(description = "현재가")
+  int currentPrice;
+
+  @Schema(description = "하락 퍼센트")
+  int discountPercent;
+
+  @Builder
+  public ProcessingRecentViewListResponse(String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt, int currentPrice,
+      int discountPercent) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    this.currentPrice = currentPrice;
+    this.discountPercent = discountPercent;
+  }
+
+  public static ProcessingRecentViewListResponse from(Tuple tuple){
+    return ProcessingRecentViewListResponse.builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .currentPrice(tuple.get("currentPrice", Long.class).intValue())
+        .discountPercent(tuple.get("discountPercent", BigDecimal.class).intValue())
+        .startedAt(tuple.get("startedAt", Date.class).toLocalDate())
+        .build();
+  }
+
+}

--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/RecentViewListRaw.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/RecentViewListRaw.java
@@ -1,0 +1,10 @@
+package com.windfall.api.mypage.dto.recentviewlist;
+
+import com.windfall.domain.auction.enums.AuctionStatus;
+
+public record RecentViewListRaw(
+    Long id,
+    AuctionStatus status
+) {
+
+}

--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/RecentViewListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/RecentViewListResponse.java
@@ -1,0 +1,37 @@
+package com.windfall.api.mypage.dto.recentviewlist;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.persistence.Tuple;
+import java.sql.Date;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "status",
+    "auctionId",
+    "title",
+    "auctionImageUrl",
+    "startPrice",
+    "startedAt"
+})
+public class RecentViewListResponse extends BaseRecentViewList{
+
+  @Builder
+  public RecentViewListResponse(String status, Long auctionId, String title, String auctionImageUrl,
+      int startPrice, LocalDate startedAt) {
+    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+  }
+
+  public static RecentViewListResponse from(Tuple tuple){
+    return RecentViewListResponse.builder()
+        .status(tuple.get("status", String.class))
+        .auctionId(tuple.get("auctionId", Long.class))
+        .title(tuple.get("title", String.class))
+        .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
+        .startPrice(tuple.get("startPrice", Long.class).intValue())
+        .startedAt(tuple.get("startedAt", Date.class).toLocalDate())
+        .build();
+  }
+}

--- a/src/main/java/com/windfall/api/mypage/service/RecentViewListService.java
+++ b/src/main/java/com/windfall/api/mypage/service/RecentViewListService.java
@@ -1,0 +1,114 @@
+package com.windfall.api.mypage.service;
+
+
+import com.windfall.api.mypage.dto.recentviewlist.BaseRecentViewList;
+import com.windfall.api.mypage.dto.recentviewlist.CompletedRecentViewListResponse;
+import com.windfall.api.mypage.dto.recentviewlist.ProcessingRecentViewListResponse;
+import com.windfall.api.mypage.dto.recentviewlist.RecentViewListRaw;
+import com.windfall.api.mypage.dto.recentviewlist.RecentViewListResponse;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import com.windfall.domain.auction.enums.AuctionStatusGroup;
+import com.windfall.domain.mypage.repository.RecentViewListQueryRepository;
+import com.windfall.global.response.SliceResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RecentViewListService {
+  
+  private final RecentViewListQueryRepository recentViewListQueryRepository;
+  
+  @Transactional
+  public SliceResponse<BaseRecentViewList> getMyRecentViewLists(Long userId, AuctionStatus filter, Pageable pageable){
+    //1. RawData 추출
+    Slice<RecentViewListRaw> rawData = recentViewListQueryRepository.getRawRecentViewList(userId, filter, pageable);
+
+    //2. 순서 저장
+    List<Long> dataSequence = rawData.getContent().stream().map(RecentViewListRaw::id).toList();
+
+    //3. 그룹화
+    Map<AuctionStatusGroup, List<Long>> groups = groupingData(rawData.getContent());
+
+    //4. 분기 처리
+    Map<Long, BaseRecentViewList> resultData = fetchDetailedData(groups, userId);
+
+    //5. 순서대로 재조립
+    List<BaseRecentViewList> resultContent = orderByResults(dataSequence, resultData);
+
+    //6. 새로운 slice로 반환
+    Slice<BaseRecentViewList> sliceData = toSlice(resultContent, rawData);
+
+    return SliceResponse.from(sliceData);
+  }
+
+  private Map<AuctionStatusGroup, List<Long>> groupingData(List<RecentViewListRaw> rawData){
+    Map<AuctionStatusGroup, List<Long>> resultData = new HashMap<>();
+
+    rawData.forEach(raw -> {
+      AuctionStatusGroup key = setGroup(raw.status());
+      resultData.computeIfAbsent(key, k -> new ArrayList<>()).add(raw.id());
+    });
+
+    return resultData;
+  }
+
+  private AuctionStatusGroup setGroup(AuctionStatus status){
+    if(status == AuctionStatus.SCHEDULED || status == AuctionStatus.CANCELED) { //예정, 취소
+      return AuctionStatusGroup.READY_CANCEL;
+    }
+    if(status == AuctionStatus.PROCESS || status == AuctionStatus.FAILED) { //진행 중, 유찰
+      return AuctionStatusGroup.PROCESS_FAILED;
+    }
+    return AuctionStatusGroup.COMPLETED_MY;
+  }
+
+  private Map<Long, BaseRecentViewList> fetchDetailedData(Map<AuctionStatusGroup, List<Long>> groups, Long userId){
+    Map<Long, BaseRecentViewList> resultData = new HashMap<>();
+
+    if(groups.containsKey(AuctionStatusGroup.READY_CANCEL)){
+      recentViewListQueryRepository.getRecentViewList(groups.get(AuctionStatusGroup.READY_CANCEL), userId).forEach(
+          data -> {
+            resultData.put(data.get("auctionId", Long.class), RecentViewListResponse.from(data));
+          }
+      );
+    }
+    if(groups.containsKey(AuctionStatusGroup.PROCESS_FAILED)){
+      recentViewListQueryRepository.getProcessingRecentViewList(groups.get(AuctionStatusGroup.PROCESS_FAILED), userId).forEach(
+          data -> {
+            resultData.put(data.get("auctionId", Long.class), ProcessingRecentViewListResponse.from(data));
+          }
+      );
+    }
+    if(groups.containsKey(AuctionStatusGroup.COMPLETED_MY)){
+      recentViewListQueryRepository.getCompletedRecentViewList(groups.get(AuctionStatusGroup.COMPLETED_MY), userId).forEach(
+          data -> {
+            resultData.put(data.get("auctionId", Long.class), CompletedRecentViewListResponse.from(data));
+          }
+      );
+    }
+
+    return resultData;
+  }
+
+  private List<BaseRecentViewList> orderByResults(List<Long> dataSequence, Map<Long, BaseRecentViewList> resultData){
+    return dataSequence.stream().map(resultData::get).toList();
+  }
+
+  private Slice<BaseRecentViewList> toSlice(List<BaseRecentViewList> resultContent, Slice<?> rawData){
+    return new SliceImpl<>(
+        resultContent,
+        rawData.getPageable(),
+        rawData.hasNext()
+    );
+  }
+  
+}

--- a/src/main/java/com/windfall/api/recentview/controller/RecentViewController.java
+++ b/src/main/java/com/windfall/api/recentview/controller/RecentViewController.java
@@ -1,0 +1,33 @@
+package com.windfall.api.recentview.controller;
+
+import com.windfall.api.recentview.service.RecentViewService;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/recentview")
+@RequiredArgsConstructor
+public class RecentViewController implements RecentViewSpecification {
+
+  private final RecentViewService recentViewService;
+
+  @Override
+  @PostMapping("/{auctionId}")
+  public ApiResponse<Void> recordRecentView(
+      @PathVariable Long auctionId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ){
+
+    Long userId = userDetails.getUserId();
+    recentViewService.record(auctionId, userId);
+
+    return ApiResponse.ok("최근 본 목록이 업데이트 되었습니다.", null);
+  }
+
+}

--- a/src/main/java/com/windfall/api/recentview/controller/RecentViewSpecification.java
+++ b/src/main/java/com/windfall/api/recentview/controller/RecentViewSpecification.java
@@ -1,0 +1,20 @@
+package com.windfall.api.recentview.controller;
+
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "RecentView", description = "최근 본 경매 내역 API")
+public interface RecentViewSpecification {
+
+  @Operation(summary = "최근 본 경매내역", description = "최근 본 경매 내역을 기록합니다. (경매 상세 페이지에서 사용됩니다.)")
+  ApiResponse<Void> recordRecentView(
+      @PathVariable Long auctionId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  );
+
+
+}

--- a/src/main/java/com/windfall/api/recentview/service/RecentViewService.java
+++ b/src/main/java/com/windfall/api/recentview/service/RecentViewService.java
@@ -1,10 +1,47 @@
 package com.windfall.api.recentview.service;
 
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.recentview.entity.RecentView;
+import com.windfall.domain.recentview.repository.RecentViewRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class RecentViewService {
 
+  private final RecentViewRepository recentViewRepository;
+  private final AuctionRepository auctionRepository;
+
+  @Transactional
+  public void record(Long auctionId, Long userId){
+
+    Auction auction = auctionRepository.findById(auctionId).orElseThrow(() -> new ErrorException(
+        ErrorCode.NOT_FOUND_AUCTION));
+
+    boolean isRecentViewExists = recentViewRepository.existsByAuctionIdAndUserId(auctionId, userId); //최근 본 목록 기록에 이미 auctionId가 있을 경우
+
+    if(isRecentViewExists){ //있으면 그냥 viewed_at 갱신
+      RecentView recentView = recentViewRepository.findByAuctionIdAndUserId(auctionId, userId);
+      recentView.updateView();
+    }else{ //없으면 새로 생성 및 카운트 후 100개 이상이면 마지막거 제거 후 추가
+      removeLastView(userId);
+      RecentView recentView = RecentView.create(auction, userId, LocalDateTime.now());
+      recentViewRepository.save(recentView);
+    }
+  }
+
+  private void removeLastView(Long userId){
+    int count = recentViewRepository.countByUserId(userId);
+
+    if(count >= 100){
+      RecentView recentView = recentViewRepository.findTop1ByUserIdOrderByViewedAt(userId);
+      recentViewRepository.delete(recentView);
+    }
+  }
 }

--- a/src/main/java/com/windfall/domain/mypage/repository/RecentViewListQueryRepository.java
+++ b/src/main/java/com/windfall/domain/mypage/repository/RecentViewListQueryRepository.java
@@ -1,0 +1,96 @@
+package com.windfall.domain.mypage.repository;
+
+import com.windfall.api.mypage.dto.recentviewlist.RecentViewListRaw;
+import com.windfall.domain.auction.entity.Auction;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import jakarta.persistence.Tuple;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RecentViewListQueryRepository extends JpaRepository<Auction, Long> {
+
+  @Query("""
+  SELECT new com.windfall.api.mypage.dto.recentviewlist.RecentViewListRaw(a.id, a.status)
+  FROM RecentView rv
+  JOIN Auction a ON rv.auction.id = a.id
+  WHERE
+  rv.userId = :id AND
+  a.status = COALESCE(:filter, a.status)
+  ORDER BY rv.viewedAt DESC
+""")
+  Slice<RecentViewListRaw> getRawRecentViewList(@Param("id") Long userId, @Param("filter") AuctionStatus filter, Pageable pageable);
+
+  @Query(value = """
+  SELECT
+  a.status AS status, -- 경매 상태 (일반, 취소)
+  a.id AS auctionId, -- 경매 아이디
+  a.title AS title, -- 경매 이름 (상품 이름)
+  ai.image AS auctionImageUrl, -- 경매 이미지 url
+  a.start_price AS startPrice, -- 시작가
+  DATE(a.started_at) AS startedAt -- 경매 시작일
+  FROM auction a
+  JOIN recent_view rv ON rv.auction_id = a.id
+  LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:auctionIds)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+  WHERE a.id IN(:auctionIds) AND rv.user_id = :userId;
+""", nativeQuery = true)
+  List<Tuple> getRecentViewList(@Param("auctionIds") List<Long> auctionIds, @Param("userId") Long userId);
+
+  @Query(value = """
+  SELECT
+  a.status AS status, -- 경매 상태 (완료)
+  a.id AS auctionId, -- 경매 아이디
+  a.title AS title, -- 경매 이름 (상품 이름)
+  ai.image AS auctionImageUrl, -- 경매 이미지 url
+  a.start_price AS startPrice, -- 시작가
+  t.final_price AS endPrice, -- 낙찰가
+  ROUND(((a.start_price - t.final_price) / a.start_price) * 100, 0) AS discountPercent, -- 할인율
+  DATE(a.started_at) AS startedAt, -- 경매 시작일
+  t.status AS tradeStatus -- 거래 상태
+  FROM auction a
+  JOIN recent_view rv ON rv.auction_id = a.id
+  JOIN trade t ON t.auction_id = a.id
+  LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:auctionIds)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+  WHERE a.id IN(:auctionIds) AND rv.user_id = :userId;
+  """, nativeQuery = true)
+  List<Tuple> getCompletedRecentViewList(@Param("auctionIds") List<Long> auctionIds, @Param("userId") Long userId);
+
+  @Query(value = """
+  SELECT
+  a.status AS status, -- 경매 상태 (진행 중, 유찰)
+  a.id AS auctionId, -- 경매 아이디
+  a.title AS title, -- 경매 이름 (상품 이름)
+  ai.image AS auctionImageUrl, -- 경매 이미지 url
+  a.start_price AS startPrice, -- 시작가
+  a.current_price AS currentPrice, -- 현재가
+  ROUND(((a.start_price - a.current_price) / a.start_price) * 100, 0) AS discountPercent, -- 할인율
+  DATE(a.started_at) AS startedAt -- 경매 시작일
+  FROM auction a
+  JOIN recent_view rv ON rv.auction_id = a.id
+  LEFT JOIN (
+    SELECT i.auction_id as auction_id, MIN(i.id) as first_image_id
+      FROM auction_image i 
+      WHERE i.auction_id IN (:auctionIds)
+      GROUP BY i.auction_id
+    ) x ON x.auction_id = a.id
+    LEFT JOIN auction_image ai ON x.first_image_id = ai.id  -- 각 경매별 가장 첫 번째 이미지 뽑기
+  WHERE a.id IN(:auctionIds) AND rv.user_id = :userId;
+  """, nativeQuery = true)
+  List<Tuple> getProcessingRecentViewList(@Param("auctionIds") List<Long> auctionIds, @Param("userId") Long userId);
+
+}

--- a/src/main/java/com/windfall/domain/recentview/entity/RecentView.java
+++ b/src/main/java/com/windfall/domain/recentview/entity/RecentView.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "recent_view",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_recent_view_auction_user",
+            columnNames = {"auction_id", "user_id"}
+        )
+    }
+)
 public class RecentView extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -31,7 +42,7 @@ public class RecentView extends BaseEntity {
     this.userId = userId;
   }
 
-  public static RecentView createRecentView(Auction auction, Long userId){
+  public static RecentView create(Auction auction, Long userId){
     return RecentView.builder()
         .auction(auction)
         .userId(userId)

--- a/src/main/java/com/windfall/domain/recentview/entity/RecentView.java
+++ b/src/main/java/com/windfall/domain/recentview/entity/RecentView.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,16 +37,25 @@ public class RecentView extends BaseEntity {
   @Column(name = "user_id", nullable = false)
   private Long userId;
 
+  @Column(name = "viewed_at", nullable = false)
+  private LocalDateTime viewedAt;
+
   @Builder
-  public RecentView(Auction auction, Long userId) {
+  public RecentView(Auction auction, Long userId, LocalDateTime viewedAt) {
     this.auction = auction;
     this.userId = userId;
+    this.viewedAt = viewedAt;
   }
 
-  public static RecentView create(Auction auction, Long userId){
+  public static RecentView create(Auction auction, Long userId, LocalDateTime viewedAt){
     return RecentView.builder()
         .auction(auction)
         .userId(userId)
+        .viewedAt(viewedAt)
         .build();
+  }
+
+  public void updateView(){
+    this.viewedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/com/windfall/domain/recentview/repository/RecentViewRepository.java
+++ b/src/main/java/com/windfall/domain/recentview/repository/RecentViewRepository.java
@@ -1,8 +1,17 @@
 package com.windfall.domain.recentview.repository;
 
 import com.windfall.domain.recentview.entity.RecentView;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RecentViewRepository extends JpaRepository<RecentView, Long> {
 
+  RecentView findByAuctionIdAndUserId(Long auctionId, Long userId);
+
+  boolean existsByAuctionIdAndUserId(Long auctionId, Long userId);
+
+  int countByUserId(Long userId);
+
+  RecentView findTop1ByUserIdOrderByViewedAt(Long userId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #123 

## 📝 변경 사항
### AS-IS
- 최근 본 목록 조회 API의 부재
- 최근 본 목록 기록 API의 부재

### TO-BE
- 조회 API 및 생성 API 생성
- 조회 API는 이전 로직과 동일합니다. 네이티브 쿼리만 봐주세요
- 기록은 최대 100건만 저장하기 때문에 100건이 넘을 경우 가장 오래된 목록을 Hard Delete합니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

### 조회 시
<img width="1774" height="786" alt="image" src="https://github.com/user-attachments/assets/c95be464-aec2-491a-be82-46259829c497" />
<img width="1774" height="786" alt="image" src="https://github.com/user-attachments/assets/1e9f1766-0028-4319-861d-028d2c519055" />

### 필터 적용
<img width="1825" height="789" alt="image" src="https://github.com/user-attachments/assets/0e823719-7ec5-4687-86cf-602a013cabc4" />

### 최근 본 목록 기록 API 실행 시 DB에 다음과 같이 저장됩니다.
<img width="727" height="179" alt="image" src="https://github.com/user-attachments/assets/f5a8e1e3-f4de-4dc8-8e79-b45e46e46575" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
경매 상세 로직에 최근 본 목록 로직까지 추가할까 고민하다가 API가 Restful해지지 않고, 경매 상세 로직에 너무 많은 책임을 주는것 같아서 그냥 최근 본 목록을 기록하는 API를 따로 빼놓았습니다. 프론트분에게 경매 상세 페이지에 들어가면 경매 상세 api, 최근 본 목록 api 두 개를 요청해달라고 한 상태입니다.

+ RecentView에 viewed_at을 추가하였습니다. modified_at으로 조회하려고 했으나 시스템적 컬럼이고 어떤 제약사항이 생길지 몰라 비즈니스적 의미가 담긴 컬럼을 따로 정의하는게 맞을것 같다고 생각합니다.

조회 로직은 이전 조회 로직과 매우 똑같으니 네이티브 쿼리 부분만 봐주시면 감사하겠습니다.