### PR TITLE
[Feature] 경매 다건 조회, 검색 응답에 찜 여부 추가

### DIFF
--- a/src/main/java/com/windfall/api/auction/controller/AuctionController.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionController.java
@@ -67,13 +67,18 @@ public class AuctionController implements AuctionSpecification {
       @RequestParam @Min(value = 1, message = "page는 1부터 시작합니다.") int page,
       @RequestParam(defaultValue = "15") int size,
       @RequestParam(defaultValue = "createDate") String sortBy,
-      @RequestParam(defaultValue = "ASC") Direction sortDirection
+      @RequestParam(defaultValue = "ASC") Direction sortDirection,
+      @AuthenticationPrincipal CustomUserDetails user
       // TODO 태그 관련 + 필터링(최신순, 인기순, 오래된 순 등등)
   ) {
+    Long userId = null;
+    if (user != null) {
+      userId = user.getUserId();
+    }
 
     PageRequest pageable = PageRequest.of(page, size, Sort.by(sortDirection, sortBy));
     SliceResponse<AuctionSearchResponse> response = auctionService.searchAuction(pageable, query,
-        category, status, minPrice, maxPrice);
+        category, status, minPrice, maxPrice, userId);
     return ApiResponse.ok("경매 검색에 성공했습니다.", response);
   }
 
@@ -82,7 +87,6 @@ public class AuctionController implements AuctionSpecification {
   public ApiResponse<AuctionListReadResponse> readAuctionList(
       @AuthenticationPrincipal CustomUserDetails user
   ) {
-
     Long userId = null;
     if (user != null) {
       userId = user.getUserId();

--- a/src/main/java/com/windfall/api/auction/controller/AuctionController.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionController.java
@@ -15,8 +15,6 @@ import com.windfall.api.auction.service.AuctionService;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.user.entity.CustomUserDetails;
-import com.windfall.global.exception.ErrorCode;
-import com.windfall.global.exception.ErrorException;
 import com.windfall.global.response.ApiResponse;
 import com.windfall.global.response.SliceResponse;
 import jakarta.validation.Valid;
@@ -28,7 +26,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -83,8 +80,15 @@ public class AuctionController implements AuctionSpecification {
   @Override
   @GetMapping
   public ApiResponse<AuctionListReadResponse> readAuctionList(
+      @AuthenticationPrincipal CustomUserDetails user
   ) {
-    AuctionListReadResponse response = auctionService.readAuctionList();
+
+    Long userId = null;
+    if (user != null) {
+      userId = user.getUserId();
+    }
+
+    AuctionListReadResponse response = auctionService.readAuctionList(userId);
     return ApiResponse.ok("경매 목록 조회에 성공했습니다.", response);
   }
 

--- a/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
@@ -85,7 +85,10 @@ public interface AuctionSpecification {
       @RequestParam(defaultValue = "createDate") String sortBy,
 
       @Parameter(description = "정렬 차림", example = "ASC")
-      @RequestParam(defaultValue = "ASC") Direction sortDirection
+      @RequestParam(defaultValue = "ASC") Direction sortDirection,
+
+      @Parameter(description = "사용자 ID", required = false, example = "1")
+      @AuthenticationPrincipal CustomUserDetails user
   );
 
   @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_AUCTION})

--- a/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
@@ -51,9 +51,10 @@ public interface AuctionSpecification {
       @Valid @RequestBody AuctionCreateRequest request
   );
 
-
   @Operation(summary = "경매 다건 조회", description = "경매 리스트들을 조회합니다.")
   ApiResponse<AuctionListReadResponse> readAuctionList(
+      @Parameter(description = "사용자 ID", required = false, example = "1")
+      @AuthenticationPrincipal CustomUserDetails user
   );
 
   @ApiErrorCodes(INVALID_PRICE)

--- a/src/main/java/com/windfall/api/auction/dto/response/AuctionSearchResponse.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/AuctionSearchResponse.java
@@ -1,5 +1,6 @@
 package com.windfall.api.auction.dto.response;
 
+import com.windfall.api.like.dto.response.AuctionLikeSupport;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -33,5 +34,20 @@ public record AuctionSearchResponse(
 
     @Schema(description = "경매 상태 (경매 예정, 경매 진행 중, 경매 종료)")
     AuctionStatus status
-) {
+) implements AuctionLikeSupport<AuctionSearchResponse> {
+
+  @Override
+  public AuctionSearchResponse withIsLiked(boolean liked) {
+    return new AuctionSearchResponse(
+        this.auctionId,
+        this.imageUrl,
+        this.title,
+        this.startPrice,
+        this.currentPrice,
+        this.discountRate,
+        liked,
+        this.startedAt,
+        this.status
+    );
+  }
 }

--- a/src/main/java/com/windfall/api/auction/dto/response/info/PopularInfo.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/info/PopularInfo.java
@@ -1,5 +1,6 @@
 package com.windfall.api.auction.dto.response.info;
 
+import com.windfall.api.like.dto.response.AuctionLikeSupport;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -29,5 +30,19 @@ public record PopularInfo(
     @Schema(description = "경매 시작 시간")
     LocalDateTime startedAt
 
-) {
+) implements AuctionLikeSupport<PopularInfo> {
+
+  @Override
+  public PopularInfo withIsLiked(boolean isLiked) {
+    return new PopularInfo(
+        auctionId,
+        imageUrl,
+        title,
+        startPrice,
+        currentPrice,
+        discountRate,
+        isLiked,
+        startedAt
+    );
+  }
 }

--- a/src/main/java/com/windfall/api/auction/dto/response/info/ProcessInfo.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/info/ProcessInfo.java
@@ -1,5 +1,6 @@
 package com.windfall.api.auction.dto.response.info;
 
+import com.windfall.api.like.dto.response.AuctionLikeSupport;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -28,6 +29,19 @@ public record ProcessInfo(
 
     @Schema(description = "경매 시작 시간")
     LocalDateTime startedAt
-) {
+) implements AuctionLikeSupport<ProcessInfo> {
 
+  @Override
+  public ProcessInfo withIsLiked(boolean isLiked) {
+    return new ProcessInfo(
+        auctionId,
+        imageUrl,
+        title,
+        startPrice,
+        currentPrice,
+        discountRate,
+        isLiked,
+        startedAt
+    );
+  }
 }

--- a/src/main/java/com/windfall/api/auction/dto/response/info/ScheduledInfo.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/info/ScheduledInfo.java
@@ -1,5 +1,6 @@
 package com.windfall.api.auction.dto.response.info;
 
+import com.windfall.api.like.dto.response.AuctionLikeSupport;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -22,5 +23,17 @@ public record ScheduledInfo(
 
     @Schema(description = "경매 시작 시간")
     LocalDateTime startedAt
-) {
+) implements AuctionLikeSupport<ScheduledInfo> {
+
+  @Override
+  public ScheduledInfo withIsLiked(boolean isLiked) {
+    return new ScheduledInfo(
+        auctionId,
+        imageUrl,
+        title,
+        startPrice,
+        isLiked,
+        startedAt
+    );
+  }
 }

--- a/src/main/java/com/windfall/api/like/dto/response/AuctionLikeSupport.java
+++ b/src/main/java/com/windfall/api/like/dto/response/AuctionLikeSupport.java
@@ -1,0 +1,8 @@
+package com.windfall.api.like.dto.response;
+
+public interface AuctionLikeSupport<T extends AuctionLikeSupport<T>> {
+
+  Long auctionId();
+
+  T withIsLiked(boolean isLiked);
+}

--- a/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
+++ b/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface AuctionLikeRepository extends JpaRepository<AuctionLike, Long> {
+public interface AuctionLikeRepository extends JpaRepository<AuctionLike, Long>, AuctionLikeRepositoryCustom {
 
   Optional<AuctionLike> findByAuctionIdAndUserId(Long auctionId, Long userId);
 

--- a/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepositoryCustom.java
+++ b/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.windfall.domain.like.repository;
+
+import java.util.List;
+
+public interface AuctionLikeRepositoryCustom {
+
+  // 사용자가 찜한 auctionId 목록 조회
+  List<Long> findLikedAuctionIdsByActivatedTrue(Long userId, List<Long> auctionIds);
+}

--- a/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepositoryCustomImpl.java
+++ b/src/main/java/com/windfall/domain/like/repository/AuctionLikeRepositoryCustomImpl.java
@@ -1,0 +1,31 @@
+package com.windfall.domain.like.repository;
+
+import static com.windfall.domain.like.entity.QAuctionLike.auctionLike;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuctionLikeRepositoryCustomImpl implements AuctionLikeRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Long> findLikedAuctionIdsByActivatedTrue(Long userId, List<Long> auctionIds) {
+
+    if (auctionIds.isEmpty()) {
+      return List.of();
+    }
+
+    return queryFactory
+        .select(auctionLike.auction.id)
+        .from(auctionLike)
+        .where(
+            auctionLike.userId.eq(userId),
+            auctionLike.auction.id.in(auctionIds),
+            auctionLike.activated.isTrue()
+        )
+        .fetch();
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #140 

## 📝 변경 사항
### AS-IS
- 경매 다건 조회, 검색 결과 응답에 로그인한 유저의 찜 여부(`isLiked`)가 반영되지 않음

### TO-BE
- 경매 다건 조회, 검색 응답 DTO(`PopularInfo`, `ProcessInfo`, `ScheduledInfo`, `AuctionSearchResponse`)에 로그인한 유저의 찜 여부를 포함하도록 개선
  - userId가 전달되면 해당 유저가 찜한 경매를 조회하여 isLiked 필드에 반영(일관성을 위해 QueryDSL 사용)
  - userId가 null이면 기존 로직 그대로 사용

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
###  [경매 조회] **userId == null** 일 때, `isLiked`가 둘 다 `false`
<img width="600" height="500" alt="스크린샷 2026-01-03 023326" src="https://github.com/user-attachments/assets/dd00055c-94cc-4665-89bb-42ae2207c152" />

### [경매 조회] **userId != null** 일 때, `isLiked`가 반영 됨
<img width="600" height="500" alt="스크린샷 2026-01-03 023452" src="https://github.com/user-attachments/assets/86c8ca7a-8043-4bcd-9950-ae648d823996" />

### [경매 검색] 위와 동일
<img width="600" height="500" alt="스크린샷 2026-01-03 030938" src="https://github.com/user-attachments/assets/1e76e4bf-eed7-457c-b9b0-c9eb9d8f36fe" />
<img width="600" height="500" alt="스크린샷 2026-01-03 031033" src="https://github.com/user-attachments/assets/28b44a24-1f08-42c8-9981-8b363d3baf5d" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 피드백 환영!