### PR TITLE
[Feature] 경매 시작 알림 기능 구현

### DIFF
--- a/src/main/java/com/windfall/api/auction/service/AuctionStateService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionStateService.java
@@ -108,10 +108,7 @@ public class AuctionStateService {
   }
 
   private void notifyAuctionStart(Auction auction) {
-    List<NotificationSetting> settings = notificationSettingRepository.findAllActiveByAuctionAndType(
-        auction.getId(),
-        NotificationSettingType.AUCTION_START
-    );
+    List<NotificationSetting> settings = getActiveAuctionStartSettings(auction);
 
     if(settings.isEmpty()) return;
 
@@ -126,5 +123,12 @@ public class AuctionStateService {
         log.error("알림 발송 실패 [User: {}]: {}", setting.getUser().getId(), e.getMessage());
       }
     }
+  }
+
+  private List<NotificationSetting> getActiveAuctionStartSettings(Auction auction) {
+    return notificationSettingRepository.findAllActiveByAuctionAndType(
+        auction.getId(),
+        NotificationSettingType.AUCTION_START
+    );
   }
 }

--- a/src/main/java/com/windfall/api/notification/service/SseService.java
+++ b/src/main/java/com/windfall/api/notification/service/SseService.java
@@ -81,4 +81,24 @@ public class SseService {
 
     sendToClient(id, "priceAlert", response);
   }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void auctionStartNotificationSend(Long userId, Long targetId, String auctionTitle) {
+    User user = userRepository.findById(userId).orElse(null);
+
+    Notification notification = Notification.create(
+        user,
+        "경매 시작 알림",
+        "관심 상품 '" + auctionTitle + "'의 경매가 시작되었습니다.",
+        false,
+        NotificationType.AUCTION_START_WISHLIST,
+        targetId
+    );
+
+    Notification saveNotification = notificationRepository.save(notification);
+    NotificationReadResponse response = NotificationReadResponse.from(saveNotification);
+    String id = String.valueOf(userId);
+
+    sendToClient(id, "auctionStartAlert", response);
+  }
 }

--- a/src/main/java/com/windfall/domain/notification/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/windfall/domain/notification/repository/NotificationSettingRepository.java
@@ -5,6 +5,7 @@ import com.windfall.domain.notification.enums.NotificationSettingType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
 
@@ -12,4 +13,13 @@ public interface NotificationSettingRepository extends JpaRepository<Notificatio
       NotificationSettingType type);
 
   List<NotificationSetting> findByUserIdAndAuctionId(Long userId, Long auctionId);
+
+  @Query("""
+      select n from NotificationSetting n
+      join fetch n.user
+      where n.auction.id = :auctionId
+        and n.type = :type
+        and n.activated = true
+      """)
+  List<NotificationSetting> findAllActiveByAuctionAndType(Long auctionId, NotificationSettingType type);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #143 

## 📝 변경 사항
### AS-IS
- 경매 시작 알림 부재

### TO-BE
1. Repository (`NotificationSettingRepository`)
     - `findAllActiveByAuctionAndType` 메서드 추가
     - N+1 문제 방지를 위해 User 엔티티를 Fetch Join으로 함께 조회

2. Service (`SseService`)
     - auctionStartNotificationSend 메서드 추가

3. Service (`AuctionStateService`)
     - 경매 상태 변경 직후 알림 발송 로직 호출하도록 수정
     - for 루프 내부를 try-catch로 감싸, 특정 유저에게 발송이 실패하더라도 다음 유저에게는 정상적으로 발송되도록 구현

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="1134" height="594" alt="image" src="https://github.com/user-attachments/assets/4be033eb-4d93-4c1b-9f62-37476fa2168f" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
1. 경매 시작 알림은 가격 하락 알림처럼 빈번하게 발생하는 이벤트가 아니라 판단하여 이벤트 기반 처리를 하지 않았습니다.
2. 메서드가 중복될 것 같아 분리하는 과정에서 @myoungjinseo 님 코드를 수정했습니다. 확인 부탁드립니다 !