### PR TITLE
[Feature] 채팅 이미지 업로드(S3) REST API 추가 및 공통 S3Uploader 구현

### DIFF
--- a/src/main/java/com/windfall/api/chat/controller/ChatImageController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatImageController.java
@@ -1,0 +1,33 @@
+package com.windfall.api.chat.controller;
+
+import com.windfall.api.chat.dto.response.ChatImageUploadResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat-images")
+public class ChatImageController implements ChatImageSpecification{
+
+  private final ChatImageService chatImageService;
+
+  @Override
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ApiResponse<List<ChatImageUploadResponse>> uploadChatImages(
+      @RequestPart(name = "uploadFiles") List<MultipartFile> files,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    Long userId = userDetails.getUserId();
+    List<ChatImageUploadResponse> response = chatImageService.uploadChatImages(userId, files);
+    return ApiResponse.ok("채팅 이미지가 업로드 되었습니다.", response);
+  }
+}

--- a/src/main/java/com/windfall/api/chat/controller/ChatImageController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatImageController.java
@@ -1,6 +1,7 @@
 package com.windfall.api.chat.controller;
 
 import com.windfall.api.chat.dto.response.ChatImageUploadResponse;
+import com.windfall.api.chat.service.ChatImageService;
 import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import java.util.List;
@@ -27,7 +28,7 @@ public class ChatImageController implements ChatImageSpecification{
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
     Long userId = userDetails.getUserId();
-    List<ChatImageUploadResponse> response = chatImageService.uploadChatImages(userId, files);
+    List<ChatImageUploadResponse> response = chatImageService.upload(files, userId);
     return ApiResponse.ok("채팅 이미지가 업로드 되었습니다.", response);
   }
 }

--- a/src/main/java/com/windfall/api/chat/controller/ChatImageSpecification.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatImageSpecification.java
@@ -1,0 +1,27 @@
+package com.windfall.api.chat.controller;
+
+import com.windfall.api.chat.dto.response.ChatImageUploadResponse;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Chat Image", description = "채팅 이미지 업로드 API")
+public interface ChatImageSpecification {
+
+  @Operation(
+      summary = "채팅 이미지 업로드",
+      description = """
+          채팅용 이미지를 S3에 업로드하고 URL 목록을 반환합니다.
+          반환된 URL로 WebSocket IMAGE 메시지를 전송하세요.
+          """
+  )
+  ApiResponse<List<ChatImageUploadResponse>> uploadChatImages(
+      @RequestPart(name = "uploadFiles") List<MultipartFile> files,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  );
+}

--- a/src/main/java/com/windfall/api/chat/dto/response/ChatImageUploadResponse.java
+++ b/src/main/java/com/windfall/api/chat/dto/response/ChatImageUploadResponse.java
@@ -1,0 +1,15 @@
+package com.windfall.api.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅 이미지 업로드 응답 DTO")
+public record ChatImageUploadResponse(
+
+    @Schema(description = "업로드된 이미지 URL")
+    String imageUrl
+
+) {
+  public static ChatImageUploadResponse of(String url) {
+    return new ChatImageUploadResponse(url);
+  }
+}

--- a/src/main/java/com/windfall/api/chat/service/ChatImageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatImageService.java
@@ -1,0 +1,43 @@
+package com.windfall.api.chat.service;
+
+import com.windfall.api.chat.dto.response.ChatImageUploadResponse;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import com.windfall.global.s3.S3Uploader;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ChatImageService {
+
+  private static final int MAX_CHAT_IMAGE_COUNT = 5;
+
+  private final S3Uploader s3Uploader;
+
+  @Transactional(readOnly = true)
+  public List<ChatImageUploadResponse> upload(List<MultipartFile> files, Long userId) {
+    validateChatImages(files);
+
+    String dirName = "chat/images/" + userId;
+
+    List<String> urls = s3Uploader.upload(files, dirName);
+
+    return urls.stream()
+        .map(ChatImageUploadResponse::of)
+        .toList();
+  }
+
+  private void validateChatImages(List<MultipartFile> files) {
+    if (files == null || files.isEmpty()) {
+      throw new ErrorException(ErrorCode.EMPTY_CHAT_IMAGE);
+    }
+    if (files.size() > MAX_CHAT_IMAGE_COUNT) {
+      throw new ErrorException(ErrorCode.INVALID_CHAT_IMAGE_COUNT);
+    }
+  }
+
+}

--- a/src/main/java/com/windfall/global/config/s3/S3Config.java
+++ b/src/main/java/com/windfall/global/config/s3/S3Config.java
@@ -1,4 +1,4 @@
-package com.windfall.global.config;
+package com.windfall.global.config.s3;
 
 
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/windfall/global/config/s3/S3Properties.java
+++ b/src/main/java/com/windfall/global/config/s3/S3Properties.java
@@ -1,0 +1,15 @@
+package com.windfall.global.config.s3;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "aws.s3")
+public class S3Properties {
+
+  private String bucketName;
+  private String baseUrl;
+
+}

--- a/src/main/java/com/windfall/global/config/s3/S3PropertiesConfig.java
+++ b/src/main/java/com/windfall/global/config/s3/S3PropertiesConfig.java
@@ -1,0 +1,9 @@
+package com.windfall.global.config.s3;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(S3Properties.class)
+public class S3PropertiesConfig {
+}

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -57,6 +57,9 @@ public enum ErrorCode {
   NOT_FOUND_BUYER(HttpStatus.NOT_FOUND, "해당 buyerId에 맞는 구매자를 db에서 찾지 못했습니다."),
   NOT_FOUND_SELLER(HttpStatus.NOT_FOUND, "해당 seelerId에 맞는 판매자를 db에서 찾지 못했습니다."),
 
+  // S3 - 파일 업로드 공통
+  INVALID_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "업로드 파일이 유효하지 않습니다."),
+
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")
   ;

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
 
   // S3 - 파일 업로드 공통
   INVALID_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "업로드 파일이 유효하지 않습니다."),
+  INVALID_DIRECTORY_NAME(HttpStatus.BAD_REQUEST, "디렉토리명이 유효하지 않습니다."),
 
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -42,6 +42,10 @@ public enum ErrorCode {
   FORBIDDEN_CHAT_ROOM(HttpStatus.FORBIDDEN, "채팅방에 접근할 수 있는 권한이 없습니다."),
   INVALID_TRADE_STATUS_FOR_CHAT(HttpStatus.BAD_REQUEST, "현재 거래 상태에서는 채팅을 조회할 수 없습니다."),
 
+  // 채팅 이미지
+  EMPTY_CHAT_IMAGE(HttpStatus.BAD_REQUEST, "업로드할 이미지가 없습니다."),
+  INVALID_CHAT_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "이미지는 최대 5장까지 업로드할 수 있습니다."),
+
   // 결제
   INVALID_PAYMENT_PROVIDER(HttpStatus.BAD_REQUEST, "결제 제공사를 선택하지 않았습니다."),
   INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "결제 수단을 선택하지 않았습니다."),
@@ -49,6 +53,10 @@ public enum ErrorCode {
   PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_REQUEST, "토스에서 해당 결제를 찾을 수 없습니다."),
   PAYMENT_ORDER_MISMATCH(HttpStatus.BAD_REQUEST, "주문번호가 일치하지 않는 보안성 에러입니다."),
   PAYMENT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 가격이 일치하지 않는 보안성 에러입니다."),
+
+  // S3 - 파일 업로드 공통
+  INVALID_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "업로드 파일이 유효하지 않습니다."),
+
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")
   ;

--- a/src/main/java/com/windfall/global/s3/S3Uploader.java
+++ b/src/main/java/com/windfall/global/s3/S3Uploader.java
@@ -55,27 +55,19 @@ public class S3Uploader {
   }
 
   private String createKey(String dirName, String originalFilename) {
-    String dir = normalizeDir(dirName);
+    validateDirName(dirName);
     String uuid = UUID.randomUUID().toString();
 
     String name =
         (originalFilename == null || originalFilename.isBlank()) ? "file" : originalFilename;
 
-    return dir + "/" + uuid + "-" + name;
+    return dirName + "/" + uuid + "-" + name;
   }
 
-  private String normalizeDir(String dirName) {
+  private void validateDirName(String dirName) {
     if (dirName == null || dirName.isBlank()) {
       throw new ErrorException(ErrorCode.INVALID_DIRECTORY_NAME);
     }
-    String dir = dirName;
-    while (dir.startsWith("/")) {
-      dir = dir.substring(1);
-    }
-    while (dir.endsWith("/")) {
-      dir = dir.substring(0, dir.length() - 1);
-    }
-    return dir;
   }
 
   private String buildUrl(String key) {

--- a/src/main/java/com/windfall/global/s3/S3Uploader.java
+++ b/src/main/java/com/windfall/global/s3/S3Uploader.java
@@ -66,7 +66,7 @@ public class S3Uploader {
 
   private String normalizeDir(String dirName) {
     if (dirName == null || dirName.isBlank()) {
-      throw new ErrorException(ErrorCode.INVALID_UPLOAD_FILE);
+      throw new ErrorException(ErrorCode.INVALID_DIRECTORY_NAME);
     }
     String dir = dirName;
     while (dir.startsWith("/")) {

--- a/src/main/java/com/windfall/global/s3/S3Uploader.java
+++ b/src/main/java/com/windfall/global/s3/S3Uploader.java
@@ -1,0 +1,88 @@
+package com.windfall.global.s3;
+
+import com.windfall.global.config.s3.S3Properties;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+  private final S3Client s3Client;
+  private final S3Properties s3Properties;
+
+  // 단일 업로드
+  public String upload(MultipartFile file, String dirName) {
+    if (file == null || file.isEmpty()) {
+      throw new ErrorException(ErrorCode.INVALID_UPLOAD_FILE);
+    }
+
+    String key = createKey(dirName, file.getOriginalFilename());
+
+    PutObjectRequest request = PutObjectRequest.builder()
+        .bucket(s3Properties.getBucketName())
+        .key(key)
+        .contentType(file.getContentType())
+        .contentLength(file.getSize())
+        .build();
+
+    try (InputStream is = file.getInputStream()) {
+      s3Client.putObject(request, RequestBody.fromInputStream(is, file.getSize()));
+      return buildUrl(key);
+    } catch (Exception e) {
+      throw new ErrorException(ErrorCode.INVALID_S3_UPLOAD);
+    }
+  }
+
+  // 다중 업로드
+  public List<String> upload(List<MultipartFile> files, String dirName) {
+    if (files == null || files.isEmpty()) {
+      throw new ErrorException(ErrorCode.INVALID_UPLOAD_FILE);
+    }
+
+    return files.stream()
+        .map(f -> upload(f, dirName))
+        .toList();
+  }
+
+  private String createKey(String dirName, String originalFilename) {
+    String dir = normalizeDir(dirName);
+    String uuid = UUID.randomUUID().toString();
+
+    String name =
+        (originalFilename == null || originalFilename.isBlank()) ? "file" : originalFilename;
+
+    return dir + "/" + uuid + "-" + name;
+  }
+
+  private String normalizeDir(String dirName) {
+    if (dirName == null || dirName.isBlank()) {
+      throw new ErrorException(ErrorCode.INVALID_UPLOAD_FILE);
+    }
+    String dir = dirName;
+    while (dir.startsWith("/")) {
+      dir = dir.substring(1);
+    }
+    while (dir.endsWith("/")) {
+      dir = dir.substring(0, dir.length() - 1);
+    }
+    return dir;
+  }
+
+  private String buildUrl(String key) {
+    String baseUrl = s3Properties.getBaseUrl();
+    if (baseUrl.endsWith("/")) {
+      return baseUrl + key;
+    }
+    return baseUrl + "/" + key;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   servlet:
     multipart:
       max-file-size: 10MB
-      max-request-size: 10MB
+      max-request-size: 50MB
   #  elasticsearch:
   #    uris: http://localhost:9200
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #147 

## 📝 변경 사항
### AS-IS
* 채팅에서 이미지 전송을 위한 업로드 API가 없어 WebSocket에서 바이너리 전송/별도 처리 고려가 필요했음
* 도메인별로 S3 업로드 로직이 분산될 가능성이 있어 중복 구현 및 유지보수 비용이 증가할 우려가 있었음

### TO-BE
* 채팅 이미지 전송을 위한 **S3 업로드 REST API**를 추가하여
  **(1) 이미지 업로드 → (2) URL 수신 → (3) WS IMAGE 메시지 전송** 흐름을 확립함
* 공통 `S3Uploader`를 도입하여

  * `dirName` 기반 key 생성으로 도메인 공통 사용 가능
  * 단일/다중 업로드를 동일한 방식으로 처리
* `S3Properties` 바인딩을 통해 S3 설정(`bucketName`, `baseUrl`)을 일관된 방식으로 관리

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 이미지 업로드 성공
<img width="1268" height="802" alt="image" src="https://github.com/user-attachments/assets/790c0ec5-930e-4517-9f1e-ce32c5d93d75" />
<img width="1620" height="261" alt="image" src="https://github.com/user-attachments/assets/2e717da2-d2ed-470e-938a-a121acad2c27" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
* 공용으로 사용할 S3Uploader 를 구현해놨습니다. 그대로 사용하시면 될 것 같습니다!
* S3Uploader 사용하실 분들은 꼭 dirName를 String dirName = "chat/images/" + userId; 이렇게 사용하시는걸 권장드립니다! 제 ChatImageService에서 upload 메서드 참고해주시면 좋을 것 같습니다.
* @myoungjinseo 명진님도 참고하셔서 사용하실 수 있으면 리팩토링 하셔도 좋을 것 같습니다!