### PR TITLE
[Refactor] 채팅방 목록 조회 API - userId 하드코딩 제거

### DIFF
--- a/src/main/java/com/windfall/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatRoomController.java
@@ -26,9 +26,9 @@ public class ChatRoomController implements ChatRoomSpecification {
   @GetMapping
   public ApiResponse<List<ChatRoomListResponse>> getChatRooms(
       @RequestParam(defaultValue = "ALL") ChatRoomScope scope,
-      @RequestParam(defaultValue = "1") Long userId
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-
+    Long userId = userDetails.getUserId();
     List<ChatRoomListResponse> response = chatRoomService.getChatRooms(userId, scope);
     return ApiResponse.ok("채팅방 목록이 조회되었습니다.", response);
   }

--- a/src/main/java/com/windfall/api/chat/controller/ChatRoomSpecification.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatRoomSpecification.java
@@ -31,8 +31,8 @@ public interface ChatRoomSpecification {
       @Parameter(description = "필터 범위 (ALL/BUY/SELL)", example = "ALL")
       @RequestParam(defaultValue = "ALL") ChatRoomScope scope,
 
-      @Parameter(description = "사용자 ID(임시, 로그인 붙이면 제거 예정)", example = "1")
-      @RequestParam(defaultValue = "1") Long userId
+      @Parameter(description = "사용자 ID", required = true, example = "1")
+      @AuthenticationPrincipal CustomUserDetails userDetails
   );
 
   @Operation(
@@ -54,6 +54,7 @@ public interface ChatRoomSpecification {
       @Parameter(description = "조회 개수", example = "20")
       @RequestParam(defaultValue = "20") int size,
 
+      @Parameter(description = "사용자 ID", required = true, example = "1")
       @AuthenticationPrincipal CustomUserDetails userDetails
   );
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #149 

## 📝 변경 사항
### AS-IS
- 채팅방 목록 조회 API에서 userId 하드코딩

### TO-BE
- 채팅방 목록 조회 API - @AuthenticationPrincipal 로 변경
## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 간단한 리팩토링입니다!