### PR TITLE
[Refactor] 구매내역 응답값에 tradeId를 제공하는 필드 추가 및 쿼리수정

### DIFF
--- a/src/main/java/com/windfall/api/mypage/dto/purchasehistory/BasePurchaseHistory.java
+++ b/src/main/java/com/windfall/api/mypage/dto/purchasehistory/BasePurchaseHistory.java
@@ -19,6 +19,9 @@ public abstract class BasePurchaseHistory {
   @Schema(description = "경매 id")
   private final Long auctionId;
 
+  @Schema(description = "거래 id")
+  private final Long tradeId;
+
   @Schema(description = "경매 제목")
   private final String title;
 
@@ -40,10 +43,11 @@ public abstract class BasePurchaseHistory {
   @Schema(description = "채팅 정보")
   private final ChatInfo chatInfo;
 
-  public BasePurchaseHistory(String status, Long auctionId, String title, String auctionImageUrl,
+  public BasePurchaseHistory(String status, Long auctionId, Long tradeId,String title, String auctionImageUrl,
       int startPrice, int endPrice, int discountPercent, LocalDate purchasedDate, Long roomId, int unreadCount) {
     this.status = status;
     this.auctionId = auctionId;
+    this.tradeId = tradeId;
     this.title = title;
     this.auctionImageUrl = auctionImageUrl;
     this.startPrice = startPrice;

--- a/src/main/java/com/windfall/api/mypage/dto/purchasehistory/ConfirmedPurchaseHistoryResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/purchasehistory/ConfirmedPurchaseHistoryResponse.java
@@ -15,10 +15,10 @@ public class ConfirmedPurchaseHistoryResponse extends BasePurchaseHistory{
   private final Long reviewId;
 
   @Builder
-  public ConfirmedPurchaseHistoryResponse(String status, Long auctionId, String title,
+  public ConfirmedPurchaseHistoryResponse(String status, Long auctionId, Long tradeId, String title,
       String auctionImageUrl, int startPrice, int endPrice, int discountPercent,
       LocalDate purchasedDate, Long roomId, int unreadCount, Long reviewId) {
-    super(status, auctionId, title, auctionImageUrl, startPrice, endPrice, discountPercent,
+    super(status, auctionId, tradeId, title, auctionImageUrl, startPrice, endPrice, discountPercent,
         purchasedDate, roomId, unreadCount);
     this.reviewId = reviewId;
   }
@@ -28,6 +28,7 @@ public class ConfirmedPurchaseHistoryResponse extends BasePurchaseHistory{
         .builder()
         .status(tuple.get("status", String.class))
         .auctionId(tuple.get("auctionId", Long.class))
+        .tradeId(tuple.get("tradeId", Long.class))
         .title(tuple.get("title", String.class))
         .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
         .startPrice(tuple.get("startPrice", Long.class).intValue())

--- a/src/main/java/com/windfall/api/mypage/dto/purchasehistory/PurchaseHistoryResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/purchasehistory/PurchaseHistoryResponse.java
@@ -12,11 +12,10 @@ import lombok.Getter;
 public class PurchaseHistoryResponse extends BasePurchaseHistory{
 
   @Builder
-  public PurchaseHistoryResponse(String status, Long auctionId, String title,
-      String auctionImageUrl,
-      int startPrice, int endPrice, int discountPercent, LocalDate purchasedDate, Long roomId,
-      int unreadCount) {
-    super(status, auctionId, title, auctionImageUrl, startPrice, endPrice, discountPercent,
+  public PurchaseHistoryResponse(String status, Long auctionId, Long tradeId, String title,
+      String auctionImageUrl, int startPrice, int endPrice, int discountPercent,
+      LocalDate purchasedDate, Long roomId, int unreadCount) {
+    super(status, auctionId, tradeId, title, auctionImageUrl, startPrice, endPrice, discountPercent,
         purchasedDate, roomId, unreadCount);
   }
 
@@ -25,6 +24,7 @@ public class PurchaseHistoryResponse extends BasePurchaseHistory{
         .builder()
         .status(tuple.get("status", String.class))
         .auctionId(tuple.get("auctionId", Long.class))
+        .tradeId(tuple.get("tradeId", Long.class))
         .title(tuple.get("title", String.class))
         .auctionImageUrl(tuple.get("auctionImageUrl", String.class))
         .startPrice(tuple.get("startPrice", Long.class).intValue())

--- a/src/main/java/com/windfall/domain/mypage/repository/PurchaseHistoryQueryRepository.java
+++ b/src/main/java/com/windfall/domain/mypage/repository/PurchaseHistoryQueryRepository.java
@@ -32,6 +32,7 @@ public interface PurchaseHistoryQueryRepository extends JpaRepository<Trade, Lon
     SELECT
     t.status AS status, -- 거래 상태
     a.id AS auctionId, -- 경매 id
+    t.id AS tradeId,
     a.title AS title, -- 상품 이름
     ai.image AS auctionImageUrl, -- 상품 대표 사진
     a.start_price AS startPrice, -- 시작가
@@ -60,6 +61,7 @@ public interface PurchaseHistoryQueryRepository extends JpaRepository<Trade, Lon
     SELECT
     t.status AS status, -- 거래 상태
     a.id AS auctionId, -- 경매 id
+    t.id AS tradeId,
     a.title AS title, -- 상품 이름
     ai.image AS auctionImageUrl, -- 상품 대표 사진
     a.start_price AS startPrice, -- 시작가


### PR DESCRIPTION
## 📌 관련 이슈
- close #153 

## 📝 변경 사항
### AS-IS
- 리뷰 API가 구현됨에 따라 구매내역에서 tradeId를 제공해주지 않았음. (리뷰 생성 API에서 사용됨)

### TO-BE
- 구매내역 API에서 각 목록의 거래 id를 제공하도록 dto와 쿼리 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

### 기존
<img width="906" height="584" alt="image" src="https://github.com/user-attachments/assets/76466913-7495-46fd-a2d7-5080169f832e" />

### tradeid 필드 추가
<img width="1535" height="847" alt="스크린샷 2026-01-04 175444" src="https://github.com/user-attachments/assets/7b678b08-3074-455f-a1e0-c9e3b5b758e4" />

필터링도 잘 동작합니다.
<img width="1525" height="790" alt="스크린샷 2026-01-04 175632" src="https://github.com/user-attachments/assets/f7107a70-62e9-4a71-a9a2-1137ecdc58ba" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
dto랑 쿼리 살짝 변경되었습니다!