### PR TITLE
[Refactor] 알림 및 웹소켓 발송 비동기 전환으로 성능 최적화

### DIFF
--- a/src/main/java/com/windfall/api/auction/service/component/StompAuctionMessageSender.java
+++ b/src/main/java/com/windfall/api/auction/service/component/StompAuctionMessageSender.java
@@ -7,10 +7,12 @@ import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.auction.enums.EmojiType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Async("socketTaskExecutor")
 public class StompAuctionMessageSender implements AuctionMessageSender {
 
   private final SimpMessagingTemplate messagingTemplate;

--- a/src/main/java/com/windfall/api/notification/service/SseService.java
+++ b/src/main/java/com/windfall/api/notification/service/SseService.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,7 +69,8 @@ public class SseService {
     }
   }
 
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Async("socketTaskExecutor")
+  @Transactional
   public void priceNotificationSend(Long userId,Long targetId,String content) {
     User user = getUserOrThrow(userId);
     Notification notification = Notification.create(user,
@@ -80,7 +82,8 @@ public class SseService {
     saveAndSend(userId, "priceAlert", notification);
   }
 
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Async("socketTaskExecutor")
+  @Transactional
   public void auctionStartNotificationSend(Long userId, Long targetId, String auctionTitle) {
     User user = getUserOrThrow(userId);
 

--- a/src/main/java/com/windfall/global/config/Async/AsyncConfig.java
+++ b/src/main/java/com/windfall/global/config/Async/AsyncConfig.java
@@ -16,7 +16,7 @@ public class AsyncConfig {
     executor.setCorePoolSize(10);
     executor.setMaxPoolSize(50); // 기본 및 대기열 초과 시 최대 스레드 수
     executor.setQueueCapacity(100); // 대기열
-    executor.setThreadNamePrefix("SocketExecutor-");
+    executor.setThreadNamePrefix("Socket-Async-");
     executor.initialize();
     return  executor;
   }

--- a/src/main/java/com/windfall/global/config/Async/AsyncConfig.java
+++ b/src/main/java/com/windfall/global/config/Async/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.windfall.global.config.Async;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+  @Bean(name = "socketTaskExecutor")
+  public Executor socketTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(10);
+    executor.setMaxPoolSize(50); // 기본 및 대기열 초과 시 최대 스레드 수
+    executor.setQueueCapacity(100); // 대기열
+    executor.setThreadNamePrefix("SocketExecutor-");
+    executor.initialize();
+    return  executor;
+  }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #156 

## 📝 변경 사항
### AS-IS
- 웹소켓 브로드캐스팅 & SSE 알림 발송이 메인 비즈니스 로직과 동기적으로 묶여 성능 저하 우려
   - 다수의 유저에게 알림을 보낼 때, I/O 대기 시간만큼 트랜잭션 점유 시간이 길어짐
   - 알림 발송 중 에러가 발생하면 핵심 경매 로직까지 롤백되거나 영향을 받을 수 있음
   
### TO-BE
1. 설정 (`AsyncConfig`)
   - `socketTaskExecuto`r 스레드 풀 정의
   - 일반적인 웹 서버 부하를 고려하여 보수적이고 안전한 수치로 설정

2. WebSocket (`StompAuctionMessageSender`)

   - 클래스 레벨에 @Async 적용
   - 가격 변동/이모지 등 모든 브로드캐스팅 별도 스레드에서 즉시 실행되도록 변경

3. SSE 알림 (`SseService`)
   - `auctionStartNotificationSend`, `priceNotificationSend` 메서드에 @Async 적용
   - `propagation = Propagation.REQUIRES_NEW` 제거
       - @Async를 통해 새로운 스레드 생성 시 기존 스레드의 트랜잭션 정보 전달 :x:
       - 즉, `REQUIRED`(기본값) 쓰든 `REQUIRES_NEW` 쓰든, 결과 일치

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
`[nio-8080-exec-4]`이 아닌 `[Socket-Async-2]`로 별도 스레드 사용 확인
<img width="1288" height="117" alt="image" src="https://github.com/user-attachments/assets/eabc9416-331e-4f32-a033-d6ee8ed7edb4" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
명진님 알림 부분도 제가 수정 했습니다 ! 확인 부탁드립니다 :)