### PR TITLE
[Feature] 경매 상세 판매자 정보조회 API 구현

### DIFF
--- a/src/main/java/com/windfall/api/auction/controller/AuctionController.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionController.java
@@ -10,8 +10,10 @@ import com.windfall.api.auction.dto.response.AuctionDetailResponse;
 import com.windfall.api.auction.dto.response.AuctionHistoryResponse;
 import com.windfall.api.auction.dto.response.AuctionListReadResponse;
 import com.windfall.api.auction.dto.response.AuctionSearchResponse;
+import com.windfall.api.auction.dto.response.AuctionSellerInfoResponse;
 import com.windfall.api.auction.service.AuctionInteractionService;
 import com.windfall.api.auction.service.AuctionService;
+import com.windfall.api.auction.service.AuctionSellerInfoService;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.user.entity.CustomUserDetails;
@@ -46,6 +48,7 @@ public class AuctionController implements AuctionSpecification {
 
   private final AuctionService auctionService;
   private final AuctionInteractionService interactionService;
+  private final AuctionSellerInfoService auctionSellerInfoService;
 
   @Override
   @PostMapping
@@ -158,4 +161,10 @@ public class AuctionController implements AuctionSpecification {
     return ApiResponse.noContent();
   }
 
+  @GetMapping("/{sellerId}/seller")
+  public ApiResponse<AuctionSellerInfoResponse> getAuctionSellerInfo(@PathVariable Long sellerId){
+    AuctionSellerInfoResponse response = auctionSellerInfoService.getAuctionSellerInfo(sellerId);
+
+    return ApiResponse.ok("판매자 정보가 조회되었습니다.", response);
+  }
 }

--- a/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionSpecification.java
@@ -19,6 +19,7 @@ import com.windfall.api.auction.dto.response.AuctionDetailResponse;
 import com.windfall.api.auction.dto.response.AuctionHistoryResponse;
 import com.windfall.api.auction.dto.response.AuctionListReadResponse;
 import com.windfall.api.auction.dto.response.AuctionSearchResponse;
+import com.windfall.api.auction.dto.response.AuctionSellerInfoResponse;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.user.entity.CustomUserDetails;
@@ -159,4 +160,8 @@ public interface AuctionSpecification {
       @Parameter(description = "사용자 ID", required = true, example = "1")
       @AuthenticationPrincipal CustomUserDetails userDetails
   );
+
+  @ApiErrorCodes({NOT_FOUND_USER})
+  @Operation(summary = "경매 판매자 상세 정보 조회", description = "해당 경매 판매자의 상세 정보를 조회합니다.")
+  ApiResponse<AuctionSellerInfoResponse> getAuctionSellerInfo(@PathVariable Long sellerId);
 }

--- a/src/main/java/com/windfall/api/auction/dto/response/AuctionSellerInfoResponse.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/AuctionSellerInfoResponse.java
@@ -1,0 +1,28 @@
+package com.windfall.api.auction.dto.response;
+
+import com.windfall.api.auction.dto.response.info.BuyerReviewInfo;
+import com.windfall.api.auction.dto.response.info.SellerAuctionsInfo;
+import com.windfall.api.auction.dto.response.stats.SellerReviewStats;
+import com.windfall.domain.user.entity.User;
+import java.util.List;
+
+public record AuctionSellerInfoResponse(
+    Long sellerId,
+    String username,
+    double rating,
+    int totalReviews,
+    List<BuyerReviewInfo> buyers,
+    List<SellerAuctionsInfo> auctions
+) {
+
+  public static AuctionSellerInfoResponse of(User user, SellerReviewStats stats, List<BuyerReviewInfo> info, List<SellerAuctionsInfo> auctions){
+    return new AuctionSellerInfoResponse(
+        user.getId(),
+        user.getNickname(),
+        stats.rating(),
+        stats.totalReviews(),
+        info,
+        auctions);
+  }
+
+}

--- a/src/main/java/com/windfall/api/auction/dto/response/AuctionSellerInfoResponse.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/AuctionSellerInfoResponse.java
@@ -4,14 +4,26 @@ import com.windfall.api.auction.dto.response.info.BuyerReviewInfo;
 import com.windfall.api.auction.dto.response.info.SellerAuctionsInfo;
 import com.windfall.api.auction.dto.response.stats.SellerReviewStats;
 import com.windfall.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record AuctionSellerInfoResponse(
+    @Schema(description = "판매자 ID")
     Long sellerId,
+
+    @Schema(description = "판매자 이름")
     String username,
+
+    @Schema(description = "평균 별점")
     double rating,
+
+    @Schema(description = "총 받은 리뷰 수")
     int totalReviews,
+
+    @Schema(description = "구매자 리뷰 (최신순 최대 4건)")
     List<BuyerReviewInfo> buyers,
+
+    @Schema(description = "판매자가 올린 경매 상품 (최신순 최대 10건)")
     List<SellerAuctionsInfo> auctions
 ) {
 

--- a/src/main/java/com/windfall/api/auction/dto/response/info/BuyerReviewInfo.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/info/BuyerReviewInfo.java
@@ -1,8 +1,15 @@
 package com.windfall.api.auction.dto.response.info;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record BuyerReviewInfo(
+    @Schema(description = "구매자 ID")
     Long buyerId,
-    String name,
+
+    @Schema(description = "구매자 이름")
+    String username,
+
+    @Schema(description = "구매자 리뷰 내용 (리뷰를 작성하지 않았을 경우 null)")
     String content
 ) {
 }

--- a/src/main/java/com/windfall/api/auction/dto/response/info/BuyerReviewInfo.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/info/BuyerReviewInfo.java
@@ -1,0 +1,8 @@
+package com.windfall.api.auction.dto.response.info;
+
+public record BuyerReviewInfo(
+    Long buyerId,
+    String name,
+    String content
+) {
+}

--- a/src/main/java/com/windfall/api/auction/dto/response/info/SellerAuctionsInfo.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/info/SellerAuctionsInfo.java
@@ -1,0 +1,16 @@
+package com.windfall.api.auction.dto.response.info;
+
+import com.windfall.api.auction.dto.response.raw.SellerAuctionsRaw;
+
+public record SellerAuctionsInfo(
+
+    Long auctionId,
+    String auctionImageUrl,
+    String title
+
+) {
+
+  public static SellerAuctionsInfo of(SellerAuctionsRaw raw, String image){
+    return new SellerAuctionsInfo(raw.auctionId(), image, raw.title());
+  }
+}

--- a/src/main/java/com/windfall/api/auction/dto/response/raw/SellerAuctionsRaw.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/raw/SellerAuctionsRaw.java
@@ -1,0 +1,8 @@
+package com.windfall.api.auction.dto.response.raw;
+
+public record SellerAuctionsRaw(
+    Long auctionId,
+    String title
+) {
+
+}

--- a/src/main/java/com/windfall/api/auction/dto/response/stats/SellerReviewStats.java
+++ b/src/main/java/com/windfall/api/auction/dto/response/stats/SellerReviewStats.java
@@ -1,0 +1,13 @@
+package com.windfall.api.auction.dto.response.stats;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SellerReviewStats(
+    @Schema(description = "평균 별점")
+    double rating,
+
+    @Schema(description = "총 리뷰 수")
+    int totalReviews
+) {
+
+}

--- a/src/main/java/com/windfall/api/auction/service/AuctionSellerInfoService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionSellerInfoService.java
@@ -1,0 +1,49 @@
+package com.windfall.api.auction.service;
+
+import com.windfall.api.auction.dto.response.AuctionSellerInfoResponse;
+import com.windfall.api.auction.dto.response.info.BuyerReviewInfo;
+import com.windfall.api.auction.dto.response.info.SellerAuctionsInfo;
+import com.windfall.api.auction.dto.response.raw.SellerAuctionsRaw;
+import com.windfall.api.auction.dto.response.stats.SellerReviewStats;
+import com.windfall.api.user.dto.response.reviewlist.AuctionImageRaw;
+import com.windfall.domain.auction.repository.AuctionImageRepository;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.domain.auction.repository.AuctionSellerInfoRepository;
+import com.windfall.domain.user.entity.User;
+import com.windfall.domain.user.repository.UserRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionSellerInfoService {
+
+  private final AuctionSellerInfoRepository auctionSellerInfoRepository;
+  private final UserRepository userRepository;
+  private final AuctionImageRepository auctionImageRepository;
+
+  public AuctionSellerInfoResponse getAuctionSellerInfo(Long sellerId){
+    User seller = userRepository.findById(sellerId).orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_USER)); //seller 검증
+
+    SellerReviewStats reviewStats = auctionSellerInfoRepository.getSellerReviewStats(sellerId); //통계 쿼리
+    List<BuyerReviewInfo> buyerReviewInfo = auctionSellerInfoRepository.getBuyerInfo(sellerId, PageRequest.of(0, 4)); //4개 뽑아오기 (구매자 리뷰 - 최신 순)
+    List<SellerAuctionsRaw> sellerAuctionsRaws = auctionSellerInfoRepository.getRawSellerAuctions(sellerId, PageRequest.of(0, 10)); //10개 뽑아오기 (판매자 경매 - 최신 순)
+
+    List<Long> auctionIds = sellerAuctionsRaws.stream().map(SellerAuctionsRaw::auctionId).toList();
+    List<AuctionImageRaw> auctionImages = auctionImageRepository.findFirstImagesProjection(auctionIds); //각 경매의 첫 번째 이미지 추출
+
+    Map<Long, String> mappingImage = auctionImages.stream().collect(Collectors.toMap(
+        AuctionImageRaw::auctionId, //매핑용 이미지 설정
+        AuctionImageRaw::auctionImageUrl));
+
+    List<SellerAuctionsInfo> sellerAuctionsInfo = sellerAuctionsRaws.stream().map(data -> SellerAuctionsInfo.of(data, mappingImage.get(data.auctionId()))).toList(); //순서대로 DTO 변환
+
+    return AuctionSellerInfoResponse.of(seller, reviewStats, buyerReviewInfo, sellerAuctionsInfo);
+  }
+}

--- a/src/main/java/com/windfall/domain/auction/repository/AuctionSellerInfoRepository.java
+++ b/src/main/java/com/windfall/domain/auction/repository/AuctionSellerInfoRepository.java
@@ -1,0 +1,41 @@
+package com.windfall.domain.auction.repository;
+
+import com.windfall.api.auction.dto.response.info.BuyerReviewInfo;
+import com.windfall.api.auction.dto.response.raw.SellerAuctionsRaw;
+import com.windfall.api.auction.dto.response.stats.SellerReviewStats;
+import com.windfall.domain.auction.entity.Auction;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AuctionSellerInfoRepository extends JpaRepository<Auction, Long> {
+  @Query("""
+  SELECT new com.windfall.api.auction.dto.response.stats.SellerReviewStats(ROUND(CAST(COALESCE(AVG(r.rating / 10.0), 0.0) as double), 1), CAST(COUNT(r.id) as int))
+  FROM Review r
+  JOIN r.trade t
+  WHERE t.sellerId = :sellerId AND t.status = "PURCHASE_CONFIRMED"
+""")
+  SellerReviewStats getSellerReviewStats(@Param("sellerId") Long sellerId);
+
+
+  @Query("""
+  SELECT new com.windfall.api.auction.dto.response.info.BuyerReviewInfo(u.id, u.nickname, r.content)
+  FROM Review r
+  JOIN r.trade t
+  JOIN User u ON t.buyerId = u.id
+  WHERE t.sellerId = :sellerId AND t.status = "PURCHASE_CONFIRMED"
+  ORDER BY r.createDate DESC
+""")
+  List<BuyerReviewInfo> getBuyerInfo(@Param("sellerId") Long sellerId, Pageable pageable);
+
+  @Query("""
+  SELECT new com.windfall.api.auction.dto.response.raw.SellerAuctionsRaw(a.id, a.title)
+  FROM Auction a
+  JOIN a.seller u
+  WHERE u.id = :sellerId
+  ORDER BY a.createDate DESC
+""")
+  List<SellerAuctionsRaw> getRawSellerAuctions(@Param("sellerId") Long sellerId, Pageable pageable);
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #155 

## 📝 변경 사항
### AS-IS
- 경매 상세에서 판매자의 정보를 조회하는 API가 없었음

### TO-BE
- 판매자 userid, username 제공
- 판매자에게 가장 최근 남긴 리뷰 4개까지 제공
- 판매자 별점 통계, 총 받은 리뷰 수 통계 제공
- 판매자가 최근 판매하고 있는 경매 상품 최근순으로 최대 10개까지 제공
- 무한스크롤이었으면 api를 분리했을텐데 10개까지 제공한다하셔서 하나의 api로 합쳤습니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

### 판매자 정보 상세조회 (DB 정보와 일치)
<img width="1695" height="829" alt="image" src="https://github.com/user-attachments/assets/2185a3ce-8e37-435c-b5d3-c2f9419485c3" />

<img width="1635" height="819" alt="image" src="https://github.com/user-attachments/assets/425f689d-9762-4969-9a72-068044b298f0" />

아무것도 없을경우 이렇게 뜹니다.
<img width="1767" height="526" alt="image" src="https://github.com/user-attachments/assets/6aaa3943-2606-42c8-8aec-1834ea796bff" />

리뷰가 없을경우에는 이렇게 뜹니다. (image null은 무시해주세요 임의로 만든 데이터라 만들지 못했어용)
<img width="1655" height="782" alt="image" src="https://github.com/user-attachments/assets/81fb2b50-5f41-4337-8cba-75805d9a5dbf" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
코드가 살짝 더러울 수 있는데 많은 피드백 바랍니다..!
spring data jpa의 top4 같은 메서드를 사용하려고 했는데 엮여있는 엔티티가 많아 프로젝션으로 하고 PageRequest로 limit처럼 사용하였습니다.