### PR TITLE
[Refactor] WebSocket STOMP 보안 리팩토링 - public/secured 엔드포인트 분리 및 인터셉터 인증 정책 통합

### DIFF
--- a/src/main/java/com/windfall/api/auction/controller/AuctionController.java
+++ b/src/main/java/com/windfall/api/auction/controller/AuctionController.java
@@ -15,10 +15,13 @@ import com.windfall.api.auction.service.AuctionService;
 import com.windfall.domain.auction.enums.AuctionCategory;
 import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
 import com.windfall.global.response.ApiResponse;
 import com.windfall.global.response.SliceResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -128,9 +131,12 @@ public class AuctionController implements AuctionSpecification {
   public void sendEmoji(
       @DestinationVariable Long auctionId,
       @Payload SellerEmojiRequest request,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
+      Principal principal) {
 
-    Long userId = userDetails.getUserId();
+    if (principal == null) {
+      throw new ErrorException(ErrorCode.INVALID_TOKEN);
+    }
+    Long userId = Long.valueOf(principal.getName());
     interactionService.broadcastSellerEmoji(auctionId, userId, request.emojiType());
   }
 

--- a/src/main/java/com/windfall/api/chat/controller/websocket/ChatWsController.java
+++ b/src/main/java/com/windfall/api/chat/controller/websocket/ChatWsController.java
@@ -5,10 +5,9 @@ import com.windfall.api.chat.dto.websocket.ChatSendRequest;
 import com.windfall.api.chat.service.websocket.ChatWsService;
 import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
-import com.windfall.global.websocket.StompAuthChannelInterceptor;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -18,25 +17,22 @@ public class ChatWsController {
   private final ChatWsService chatWsService;
 
   @MessageMapping("/chat.send")
-  public void send(ChatSendRequest request, SimpMessageHeaderAccessor accessor) {
-    Long userId = getUserIdFromSession(accessor);
+  public void send(ChatSendRequest request, Principal principal) {
+    validatePrincipal(principal);
+    Long userId = Long.valueOf(principal.getName());
     chatWsService.sendMessage(userId, request);
   }
 
   @MessageMapping("/chat.read")
-  public void read(ChatReadRequest request, SimpMessageHeaderAccessor accessor) {
-    Long userId = getUserIdFromSession(accessor);
+  public void read(ChatReadRequest request, Principal principal) {
+    validatePrincipal(principal);
+    Long userId = Long.valueOf(principal.getName());
     chatWsService.markAsRead(userId, request.chatRoomId());
   }
 
-  private Long getUserIdFromSession(SimpMessageHeaderAccessor accessor) {
-    if (accessor.getSessionAttributes() == null) {
+  private void validatePrincipal(Principal principal) {
+    if (principal == null) {
       throw new ErrorException(ErrorCode.INVALID_TOKEN);
     }
-    Object v = accessor.getSessionAttributes().get(StompAuthChannelInterceptor.ATTR_WS_USER_ID);
-    if (v == null) throw new ErrorException(ErrorCode.INVALID_TOKEN);
-    if (v instanceof Long l) return l;
-    if (v instanceof Integer i) return i.longValue();
-    return Long.valueOf(String.valueOf(v));
   }
 }

--- a/src/main/java/com/windfall/api/chat/service/websocket/ChatWsService.java
+++ b/src/main/java/com/windfall/api/chat/service/websocket/ChatWsService.java
@@ -71,12 +71,12 @@ public class ChatWsService {
     Long sellerId = trade.getSellerId();
 
     // 발신자: unread 변화 없음, 마지막 메시지 갱신
-    sendRoomUpdateToUser(wsUserKey(sender), chatRoom, 0, false);
+    sendRoomUpdateToUser(String.valueOf(sender.getId()), chatRoom, 0, false);
 
     // 수신자: unread +1, 마지막 메시지 갱신
     Long receiverId = sender.getId().equals(buyerId) ? sellerId : buyerId;
     User receiver = userService.getUserById(receiverId);
-    sendRoomUpdateToUser(wsUserKey(receiver), chatRoom, +1, false);
+    sendRoomUpdateToUser(String.valueOf(receiver.getId()), chatRoom, +1, false);
   }
 
   public void markAsRead(Long userId, Long chatRoomId) {
@@ -90,7 +90,7 @@ public class ChatWsService {
     int updated = chatMessageRepository.markAllAsReadExcludingSender(chatRoomId, userId);
 
     // 본인 목록: unread 0으로 리셋 이벤트
-    sendRoomUpdateToUser(wsUserKey(me), chatRoom, 0, true);
+    sendRoomUpdateToUser(String.valueOf(me.getId()), chatRoom, 0, true);
 
     // 상대에게 “상대가 읽음 처리했다” 이벤트 보내기 -> 추후 리팩토링 및 추가 예정
     // updated > 0일 때만 보내도 됨
@@ -103,10 +103,6 @@ public class ChatWsService {
         room.getLastMessageType(), room.getLastMessageAt(), unreadDelta, resetUnread);
 
     messagingTemplate.convertAndSendToUser(wsUserKey, "/queue/chat.rooms", update);
-  }
-
-  private String wsUserKey(User user) {
-    return user.getProvider().name() + "_" + user.getProviderUserId();
   }
 
   private void validateParticipant(Trade trade, Long userId) {

--- a/src/main/java/com/windfall/global/config/WebSocketConfig.java
+++ b/src/main/java/com/windfall/global/config/WebSocketConfig.java
@@ -27,7 +27,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // 인증 필요 endpoint
     registry.addEndpoint("/ws-stomp")
+        .setAllowedOriginPatterns("*")
+        .addInterceptors(wsHandshakeInterceptor)
+        .withSockJS();
+
+    // 인증 불필요 endpoint
+    registry.addEndpoint("/ws-stomp-public")
         .setAllowedOriginPatterns("*")
         .addInterceptors(wsHandshakeInterceptor)
         .withSockJS();

--- a/src/main/java/com/windfall/global/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/windfall/global/websocket/StompAuthChannelInterceptor.java
@@ -9,54 +9,89 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
-  public static final String ATTR_WS_USER_ID = "WS_USER_ID";
-
   private final JwtProvider jwtProvider;
 
   @Override
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
 
-    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    StompHeaderAccessor accessor =
+        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
+    if (accessor == null) return message;
+
+    accessor.setLeaveMutable(true);
+
+    // 1) CONNECT: 토큰 있으면 Principal을 "userId"로 강제 세팅
     if (StompCommand.CONNECT.equals(accessor.getCommand())) {
 
-      String auth = accessor.getFirstNativeHeader("Authorization");
-      String token = extractBearer(auth);
+      // Authorization or 쿠키 fallback
+      String token = resolveToken(accessor);
 
-      if (token == null) {
-        throw new ErrorException(ErrorCode.INVALID_TOKEN);
+      if (token != null) {
+        if (!jwtProvider.validateToken(token)) {
+          throw new ErrorException(ErrorCode.INVALID_TOKEN);
+        }
+
+        Long userId = jwtProvider.getUserId(token);
+        if (userId == null) {
+          throw new ErrorException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // Principal을 userId로 세팅
+        accessor.setUser(new StompPrincipal(String.valueOf(userId)));
       }
-
-      if (!jwtProvider.validateToken(token)) {
-        throw new ErrorException(ErrorCode.INVALID_TOKEN);
-      }
-
-      Long userId = jwtProvider.getUserId(token);
-      if (userId == null) {
-        throw new ErrorException(ErrorCode.INVALID_TOKEN);
-      }
-
-      if (accessor.getSessionAttributes() != null) {
-        accessor.getSessionAttributes().put(ATTR_WS_USER_ID, userId);
-      }
-
     }
 
-    return message;
+    // 2) SEND/SUBSCRIBE에서 인증 강제
+    if (StompCommand.SEND.equals(accessor.getCommand())) {
+      String dest = accessor.getDestination();
+      if (dest != null && (dest.startsWith("/app/chat.") || dest.startsWith("/app/auctions/"))) {
+        requireAuthenticated(accessor);
+      }
+    }
+
+    if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+      String dest = accessor.getDestination();
+      if (dest != null && dest.startsWith("/user/")) {
+        requireAuthenticated(accessor);
+      }
+    }
+
+    return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
+  }
+
+  private void requireAuthenticated(StompHeaderAccessor accessor) {
+    if (accessor.getUser() == null) {
+      throw new ErrorException(ErrorCode.INVALID_TOKEN);
+    }
+  }
+
+  private String resolveToken(StompHeaderAccessor accessor) {
+    // 1) Authorization 헤더 우선
+    String auth = accessor.getFirstNativeHeader("Authorization");
+    String token = extractBearer(auth);
+    if (token != null) return token;
+
+    // 2) 쿠키 fallback (HandshakeInterceptor)
+    if (accessor.getSessionAttributes() != null) {
+      Object v = accessor.getSessionAttributes().get(WsHandshakeInterceptor.ATTR_ACCESS_TOKEN);
+      if (v != null) return String.valueOf(v);
+    }
+    return null;
   }
 
   private String extractBearer(String authHeader) {
     if (authHeader == null) return null;
     String v = authHeader.trim();
-
     if (v.startsWith("Bearer ")) return v.substring(7).trim();
-
     return null;
   }
 }

--- a/src/main/java/com/windfall/global/websocket/StompPrincipal.java
+++ b/src/main/java/com/windfall/global/websocket/StompPrincipal.java
@@ -5,8 +5,8 @@ import java.security.Principal;
 public class StompPrincipal implements Principal {
   private final String name;
 
-  public StompPrincipal(Long userId) {
-    this.name = String.valueOf(userId);
+  public StompPrincipal(String name) {
+    this.name = name;
   }
   @Override
   public String getName() {

--- a/src/main/resources/html/WebSocketIntegrationTest.html
+++ b/src/main/resources/html/WebSocketIntegrationTest.html
@@ -1,62 +1,123 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="UTF-8">
-  <title>이모지 테스트</title>
+  <meta charset="UTF-8" />
+  <title>🔥 경매 이모지 테스트</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 900px; margin: 20px auto; }
+    input, button, select { padding: 8px; margin: 4px; }
+    .row { margin: 10px 0; }
+    #messages, #errors { background: #111; color: #0f0; padding: 12px; min-height: 140px; white-space: pre-wrap; }
+    #errors { color: #ff5; }
+  </style>
 </head>
 <body>
-<h2>🔥 경매 이모지 테스트</h2>
-<div>
-  <button onclick="connect()">1. 연결하기</button>
-  <button onclick="sendEmoji('FIRE')">2. 🔥 불꽃 쏘기</button>
-  <button onclick="sendEmoji('LIKE')">3. 👍 좋아요 쏘기</button>
+<h2>🔥 경매 이모지(WebSocket) 테스트</h2>
+
+<div class="row">
+  <label>endpoint:</label>
+  <select id="endpoint">
+    <option value="http://localhost:8080/ws-stomp">/ws-stomp (SECURED, 토큰 필수)</option>
+    <option value="http://localhost:8080/ws-stomp-public">/ws-stomp-public (PUBLIC, 토큰 선택)</option>
+  </select>
 </div>
+
+<div class="row">
+  <label>auctionId:</label>
+  <input id="auctionId" value="1" style="width: 100px;" />
+
+  <label>accessToken(선택):</label>
+  <input id="token" style="width: 520px;" placeholder="Bearer 없이 토큰만 넣어도 됨" />
+
+  <button onclick="connect()">1) 연결하기</button>
+  <button onclick="disconnect()">연결 끊기</button>
+</div>
+
+<div class="row">
+  <button onclick="sendEmoji('FIRE')">2) 🔥 불꽃 쏘기</button>
+  <button onclick="sendEmoji('LIKE')">3) 👍 좋아요 쏘기</button>
+</div>
+
 <hr/>
-<h3>📩 받은 메시지 (구독 화면)</h3>
+
+<h3>📩 받은 메시지 (/topic/auction/{id})</h3>
 <div id="messages"></div>
 
+<h3>⚠️ 에러 (/user/queue/errors) - 로그인일 때만 수신 가능</h3>
+<div id="errors"></div>
+
 <script>
-  var stompClient = null;
+  let stompClient = null;
+
+  function append(id, msg) {
+    const el = document.getElementById(id);
+    el.textContent += msg + "\n";
+  }
 
   function connect() {
-    // 1. 연결 주소: WebSocketConfig의 addEndpoint 주소
-    var socket = new SockJS('http://localhost:8080/ws-stomp');
+    const endpoint = document.getElementById("endpoint").value;
+    const auctionId = document.getElementById("auctionId").value.trim();
+    const token = document.getElementById("token").value.trim();
+
+    if (!auctionId) {
+      alert("auctionId를 입력하세요");
+      return;
+    }
+
+    const socket = new SockJS(endpoint);
     stompClient = Stomp.over(socket);
 
-    stompClient.connect({}, function (frame) {
-      console.log('Connected: ' + frame);
-      alert("연결 성공!");
+    // 디버그 로그 보고 싶으면 주석 해제
+    // stompClient.debug = (str) => append("messages", "[stomp] " + str);
 
-      // 2. 구독 주소: /topic/auction/{경매ID}
-      // (경매 ID는 1번이라고 가정)
-      stompClient.subscribe('/topic/auction/1', function (message) {
-        showEmoji(JSON.parse(message.body));
+    const headers = {};
+    if (token) {
+      headers["Authorization"] = token.startsWith("Bearer ") ? token : ("Bearer " + token);
+    }
+
+    stompClient.connect(headers, function(frame) {
+      alert("연결 성공!");
+      append("messages", "✅ CONNECTED: " + frame);
+
+      // 1) 경매 토픽 구독 (비로그인도 가능하게 설계되어 있음)
+      stompClient.subscribe(`/topic/auction/${auctionId}`, function(message) {
+        const body = message.body;
+        append("messages", "📩 " + body);
       });
+
+      // 2) 에러 구독 (로그인 사용자만 가능: /user/** 구독은 인증 필요)
+      stompClient.subscribe(`/user/queue/errors`, function(message) {
+        append("errors", "❌ " + message.body);
+      });
+
+      append("messages", `✅ SUBSCRIBED: /topic/auction/${auctionId}`);
+      append("messages", `✅ SUBSCRIBED: /user/queue/errors (로그인 시)`);
+    }, function(err) {
+      append("errors", "❌ CONNECT ERROR: " + JSON.stringify(err));
+      alert("연결 실패 - 콘솔/에러창 확인");
     });
+  }
+
+  function disconnect() {
+    if (stompClient) {
+      stompClient.disconnect(() => append("messages", "👋 DISCONNECTED"));
+    }
+    stompClient = null;
   }
 
   function sendEmoji(type) {
-    // 3. 전송 주소: /pub + 컨트롤러 매핑 주소
-    // Config에서 "/pub" 설정, Controller에서 "/auctions/1/emoji" 설정
-    // => 합쳐서 "/pub/auctions/1/emoji"
+    if (!stompClient) return alert("먼저 연결하세요");
+    const auctionId = document.getElementById("auctionId").value.trim();
+    if (!auctionId) return alert("auctionId를 입력하세요");
 
-    var payload = JSON.stringify({
-      'emojiType': type
-    });
+    const payload = JSON.stringify({ emojiType: type });
 
-    // 헤더에 userId를 담아서 보냄 (우리가 만든 임시 로직)
-    stompClient.send("/app/auctions/1/emoji", { 'userId': '1' }, payload);
-  }
-
-  function showEmoji(message) {
-    var messagesDiv = document.getElementById("messages");
-    var p = document.createElement("p");
-    p.style.fontSize = "20px";
-    // 서버가 보내준 메시지 출력
-    p.textContent = `[경매방 ${message.auctionId}] ${message.emojiType} 이모지가 도착했습니다!`;
-    messagesDiv.appendChild(p);
+    // ✅ 서버 @MessageMapping("/auctions/{auctionId}/emoji") 이므로:
+    // SEND destination = /app/auctions/{auctionId}/emoji
+    stompClient.send(`/app/auctions/${auctionId}/emoji`, {}, payload);
+    append("messages", `➡️ SEND: ${payload}`);
   }
 </script>
 </body>


### PR DESCRIPTION
## 📌 관련 이슈
- close #160 

## 📝 변경 사항
### AS-IS
* WebSocket(STOMP) 인증 정책이 명확히 분리되어 있지 않아, 기능별(채팅/경매 등) 보안 요구사항을 일관되게 적용하기 어려웠음
* CONNECT 시점 또는 SUBSCRIBE/SEND 시점에서 인증 여부에 따른 처리 흐름이 명확하지 않아 프론트 연동 시 혼선 발생 가능
* 토큰 전달 방식이 제한적이거나 테스트용 우회 로직이 섞일 가능성이 있어 운영 보안 기준과의 괴리가 존재

### TO-BE
* WebSocket 엔드포인트를 **SECURED / PUBLIC** 으로 분리하여 보안 정책을 명확히 적용

  * `/ws-stomp` : 인증 필수 연결
  * `/ws-stomp-public` : 비로그인 허용 연결
* HandshakeInterceptor에서 엔드포인트 타입을 세션에 저장하고, ChannelInterceptor에서 프레임 단위로 정책 적용

  * `CONNECT` 단계에서 SECURED는 토큰 없으면 차단
  * `SEND`/`SUBSCRIBE` 단계에서 보호 destination에 대한 인증 강제
* 프론트 연동을 고려해 토큰 전달 방식을 표준화/확장

  * Authorization 헤더 우선, 쿠키 fallback 지원
* WebSocket 예외 발생 시 클라이언트가 확인할 수 있도록 `/user/queue/errors` 에 에러 이벤트 전송 처리 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
* 채팅 테스트는 완료했고 채팅 이모지 테스트는 로컬에서 테스트 진행하지 못했습니다. 프론트에 전달 후 잘 되는지 테스트 해보려고 합니다
