### PR TITLE
[Feature] 알림 세팅 요청 값으로 price 추가, 관련 로직 추가

### DIFF
--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
@@ -28,8 +28,12 @@ public class NotificationSettingController implements NotificationSettingSpecifi
       @PathVariable Long auctionId,
       @AuthenticationPrincipal CustomUserDetails user
   ) {
-    ReadNotySettingResponse response = notificationSettingService
-        .read(auctionId, user.getUserId());
+    Long userId = null;
+    if (user != null) {
+      userId = user.getUserId();
+    }
+
+    ReadNotySettingResponse response = notificationSettingService.read(auctionId, userId);
     return ApiResponse.ok("알림 세팅 조회를 성공했습니다.", response);
   }
 

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
@@ -28,12 +28,7 @@ public class NotificationSettingController implements NotificationSettingSpecifi
       @PathVariable Long auctionId,
       @AuthenticationPrincipal CustomUserDetails user
   ) {
-    Long userId = null;
-    if (user != null) {
-      userId = user.getUserId();
-    }
-
-    ReadNotySettingResponse response = notificationSettingService.read(auctionId, userId);
+    ReadNotySettingResponse response = notificationSettingService.read(auctionId, user.getUserId());
     return ApiResponse.ok("알림 세팅 조회를 성공했습니다.", response);
   }
 

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
@@ -1,6 +1,8 @@
 package com.windfall.api.notificationsetting.controller;
 
+import static com.windfall.global.exception.ErrorCode.INVALID_PRICE_NOTIFICATION;
 import static com.windfall.global.exception.ErrorCode.NOT_FOUND_AUCTION;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_PRICE_REACHED_NOTY;
 import static com.windfall.global.exception.ErrorCode.NOT_FOUND_USER;
 
 import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
@@ -28,7 +30,7 @@ public interface NotificationSettingSpecification {
       @AuthenticationPrincipal CustomUserDetails user
   );
 
-  @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_AUCTION})
+  @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_AUCTION, INVALID_PRICE_NOTIFICATION, NOT_FOUND_PRICE_REACHED_NOTY})
   @Operation(summary = "알림 세팅 수정", description = "알림 세팅을 수정합니다.")
   ApiResponse<UpdateNotySettingResponse> update(
       @Parameter(description = "경매 ID", required = true, example = "1")
@@ -40,7 +42,8 @@ public interface NotificationSettingSpecification {
               {
                 "auctionStart": true,
                 "auctionEnd": true,
-                "priceReached": true
+                "priceReached": true,
+                "price": 10000
               }
               """
       )

--- a/src/main/java/com/windfall/api/notificationsetting/dto/request/UpdateNotySettingRequest.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/request/UpdateNotySettingRequest.java
@@ -12,6 +12,9 @@ public record UpdateNotySettingRequest (
     boolean auctionEnd,
 
     @Schema(description = "가격 도달 설정 여부", example = "true")
-    boolean priceReached
+    boolean priceReached,
+
+    @Schema(description = "가격 도달 기준값", example = "10000")
+    Long price
 ){
 }

--- a/src/main/java/com/windfall/api/notificationsetting/dto/response/ReadNotySettingResponse.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/response/ReadNotySettingResponse.java
@@ -1,6 +1,7 @@
 package com.windfall.api.notificationsetting.dto.response;
 
 import com.windfall.domain.notification.entity.NotificationSetting;
+import com.windfall.domain.notification.entity.PriceNotification;
 import com.windfall.domain.notification.enums.NotificationSettingType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -17,14 +18,20 @@ public record ReadNotySettingResponse (
     boolean auctionEnd,
 
     @Schema(description = "가격 도달 설정 여부")
-    boolean priceReached
+    boolean priceReached,
+
+    @Schema(description = "가격 도달 기준값")
+    Long price
 ){
 
   public static ReadNotySettingResponse allDisabled() {
-    return new ReadNotySettingResponse(false, false, false);
+    return new ReadNotySettingResponse(false, false, false, null);
   }
 
-  public static ReadNotySettingResponse from(List<NotificationSetting> settings) {
+  public static ReadNotySettingResponse of(
+      List<NotificationSetting> settings,
+      PriceNotification priceNotification
+  ) {
     Map<NotificationSettingType, Boolean> map =
         settings.stream()
             .collect(Collectors.toMap(
@@ -35,7 +42,8 @@ public record ReadNotySettingResponse (
     return new ReadNotySettingResponse(
         map.getOrDefault(NotificationSettingType.AUCTION_START, false),
         map.getOrDefault(NotificationSettingType.AUCTION_END, false),
-        map.getOrDefault(NotificationSettingType.PRICE_REACHED, false)
+        map.getOrDefault(NotificationSettingType.PRICE_REACHED, false),
+        priceNotification != null ? priceNotification.getTargetPrice() : null
     );
   }
 }

--- a/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateNotySettingResponse.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateNotySettingResponse.java
@@ -13,14 +13,18 @@ public record UpdateNotySettingResponse (
     boolean auctionEnd,
 
     @Schema(description = "가격 도달 설정 여부")
-    boolean priceReached
+    boolean priceReached,
+
+    @Schema(description = "가격 도달 기준값")
+    Long price
 ) {
 
   public static UpdateNotySettingResponse from(UpdateNotySettingRequest request) {
       return new UpdateNotySettingResponse(
           request.auctionStart(),
           request.auctionEnd(),
-          request.priceReached()
+          request.priceReached(),
+          request.price()
       );
   }
 }

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -30,6 +30,10 @@ public class NotificationSettingService {
 
   @Transactional(readOnly = true)
   public ReadNotySettingResponse read(Long auctionId, Long userId) {
+    if (userId == null) {
+      return ReadNotySettingResponse.allDisabled();
+    }
+
     List<NotificationSetting> settings =
         notificationSettingRepository.findByUserIdAndAuctionId(userId, auctionId);
 
@@ -38,7 +42,11 @@ public class NotificationSettingService {
       return ReadNotySettingResponse.allDisabled();
     }
 
-    return ReadNotySettingResponse.from(settings);
+    PriceNotification priceNotification = priceNotificationRepository
+            .findByUserIdAndAuctionId(userId, auctionId)
+            .orElse(null);
+
+    return ReadNotySettingResponse.of(settings, priceNotification);
   }
 
   @Transactional

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -30,10 +30,6 @@ public class NotificationSettingService {
 
   @Transactional(readOnly = true)
   public ReadNotySettingResponse read(Long auctionId, Long userId) {
-    if (userId == null) {
-      return ReadNotySettingResponse.allDisabled();
-    }
-
     List<NotificationSetting> settings =
         notificationSettingRepository.findByUserIdAndAuctionId(userId, auctionId);
 

--- a/src/main/java/com/windfall/domain/notification/entity/PriceNotification.java
+++ b/src/main/java/com/windfall/domain/notification/entity/PriceNotification.java
@@ -1,12 +1,10 @@
 package com.windfall.domain.notification.entity;
 
 import com.windfall.global.entity.BaseEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,4 +29,12 @@ public class PriceNotification extends BaseEntity {
   private Long targetPrice;
 
   private Boolean notified;
+
+  public void updateTargetPrice(Long price) {
+    targetPrice = price;
+  }
+
+  public void resetNotified() {
+    notified = false;
+  }
 }

--- a/src/main/java/com/windfall/domain/notification/repository/PriceNotificationRepository.java
+++ b/src/main/java/com/windfall/domain/notification/repository/PriceNotificationRepository.java
@@ -2,6 +2,7 @@ package com.windfall.domain.notification.repository;
 
 import com.windfall.domain.notification.entity.PriceNotification;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +18,6 @@ where a.auctionId = :auctionId
       @Param("auctionId") Long auctionId,
       @Param("currentPrice") Long currentPrice
   );
+
+  Optional<PriceNotification> findByUserIdAndAuctionId(Long userId, Long auctionId);
 }

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
   //알림
   NOT_FOUND_NOTIFICATION(HttpStatus.NOT_FOUND,"존재하지 않는 알림입니다."),
   INVALID_NOTIFICATION(HttpStatus.FORBIDDEN, "해당 유저의 알림이 아닙니다."),
+  INVALID_PRICE_NOTIFICATION(HttpStatus.BAD_REQUEST, "가격 도달 알림을 위한 가격이 유효하지 않습니다."),
+  NOT_FOUND_PRICE_REACHED_NOTY(HttpStatus.INTERNAL_SERVER_ERROR, "알림 설정 처리 중 내부 오류로 가격 도달 알림이 활성화 되지 않았습니다."),
 
   // 채팅
   NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),

--- a/src/test/java/com/windfall/api/notificationsetting/NotificationSettingServiceTest.java
+++ b/src/test/java/com/windfall/api/notificationsetting/NotificationSettingServiceTest.java
@@ -71,7 +71,7 @@ class NotificationSettingServiceTest {
   @DisplayName("[알림 세팅 수정1] 알림 세팅을 수정하는 경우")
   void success2() {
     // given
-    UpdateNotySettingRequest request = new UpdateNotySettingRequest(true, false, true);
+    UpdateNotySettingRequest request = new UpdateNotySettingRequest(true, true, false, null);
 
     when(userRepository.findById(userId)).thenReturn(Optional.of(user));
     when(auctionRepository.findById(auctionId)).thenReturn(Optional.of(auction));
@@ -97,8 +97,8 @@ class NotificationSettingServiceTest {
 
     // then
     assertTrue(response.auctionStart());
-    assertFalse(response.auctionEnd());
-    assertTrue(response.priceReached());
+    assertTrue(response.auctionEnd());
+    assertFalse(response.priceReached());
 
     verify(notificationSettingRepository, times(3)).save(any(NotificationSetting.class));
   }


### PR DESCRIPTION
## 📌 관련 이슈
- close #151 

## 📝 변경 사항
### AS-IS
- 알림 세팅 업데이트 요청 값에 `price`값 부재
- 알림 세팅 조회 응답 값에 `price`값 부재
- ~비회원일 때 알림 세팅 조회를 못 함~

### TO-BE
- 알림 세팅 업데이트 요청, 응답 값에 `price`값 추가
  - `PRICE_REACHED=true` 일 때, PriceNotification 추가 및 수정함
  👉 **최초로 하나의 row를 생성하고 이후엔 같은 row를 수정하는 형식!**
  👉 즉, 한 유저의 & 한 게시물의 PriceNotification row는 하나입니다.
- 알림 세팅 조회 응답 값에 `price`값 추가
- ~비회원일 때 알림 세팅 조회 가능하게 변경~

## 🔍 테스트
- [ ] 테스트 코드 작성
- [X] API 테스트 - 알림 세팅 조회만
- [X] 로컬 테스트

## 📸 스크린샷
<img width="653" height="285" alt="image" src="https://github.com/user-attachments/assets/02791c79-8e81-438d-aca8-6e3c82da89d0" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 알림 세팅 토글만 생각하고 price 필드를 못 넣어서 추가했습니다.
- 참고로 **경매 가격 도달 알림을 하시는 분**은 `PRICE_REACHED=false` 일 땐 가격 도달 알림이 가지 않게 구현해야 할 것 같습니다!(NotificationSettingService의 `isEnabled()`를 쓰면 되지 않을까 싶습니다)