### PR TITLE
[Docs] 채팅 관련 API Swagger - ApiErrorCodes 추가

### DIFF
--- a/src/main/java/com/windfall/api/chat/controller/ChatImageSpecification.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatImageSpecification.java
@@ -1,7 +1,15 @@
 package com.windfall.api.chat.controller;
 
+import static com.windfall.global.exception.ErrorCode.EMPTY_CHAT_IMAGE;
+import static com.windfall.global.exception.ErrorCode.INVALID_CHAT_IMAGE_COUNT;
+import static com.windfall.global.exception.ErrorCode.INVALID_DIRECTORY_NAME;
+import static com.windfall.global.exception.ErrorCode.INVALID_S3_UPLOAD;
+import static com.windfall.global.exception.ErrorCode.INVALID_UPLOAD_FILE;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_USER;
+
 import com.windfall.api.chat.dto.response.ChatImageUploadResponse;
 import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.config.swagger.ApiErrorCodes;
 import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +21,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Chat Image", description = "채팅 이미지 업로드 API")
 public interface ChatImageSpecification {
 
+  @ApiErrorCodes({NOT_FOUND_USER, EMPTY_CHAT_IMAGE, INVALID_CHAT_IMAGE_COUNT, INVALID_UPLOAD_FILE,
+      INVALID_S3_UPLOAD, INVALID_DIRECTORY_NAME})
   @Operation(
       summary = "채팅 이미지 업로드",
       description = """

--- a/src/main/java/com/windfall/api/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatMessageController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chat-rooms")
-public class ChatMessageController implements ChatMessageControllerSpecification {
+public class ChatMessageController implements ChatMessageSpecification {
 
   private final ChatMessageService chatMessageService;
 

--- a/src/main/java/com/windfall/api/chat/controller/ChatMessageSpecification.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatMessageSpecification.java
@@ -1,7 +1,12 @@
 package com.windfall.api.chat.controller;
 
+import static com.windfall.global.exception.ErrorCode.FORBIDDEN_CHAT_ROOM;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_CHAT_ROOM;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_USER;
+
 import com.windfall.api.chat.dto.response.ChatReadMarkResponse;
 import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.config.swagger.ApiErrorCodes;
 import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -10,8 +15,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "ChatMessage", description = "채팅 메시지 API")
-public interface ChatMessageControllerSpecification {
+public interface ChatMessageSpecification {
 
+  @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_CHAT_ROOM, FORBIDDEN_CHAT_ROOM})
   @Operation(
       summary = "채팅 메시지 읽음 처리",
       description = "채팅방에 들어갈 때 호출. 해당 채팅방에서 '내가 보낸 메시지'를 제외한, 읽지 않은 메시지(isRead=false)를 모두 읽음 처리합니다."

--- a/src/main/java/com/windfall/api/chat/controller/ChatRoomSpecification.java
+++ b/src/main/java/com/windfall/api/chat/controller/ChatRoomSpecification.java
@@ -1,9 +1,15 @@
 package com.windfall.api.chat.controller;
 
+import static com.windfall.global.exception.ErrorCode.FORBIDDEN_CHAT_ROOM;
+import static com.windfall.global.exception.ErrorCode.INVALID_TRADE_STATUS_FOR_CHAT;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_CHAT_ROOM;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_USER;
+
 import com.windfall.api.chat.dto.request.enums.ChatRoomScope;
 import com.windfall.api.chat.dto.response.ChatRoomDetailResponse;
 import com.windfall.api.chat.dto.response.ChatRoomListResponse;
 import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.config.swagger.ApiErrorCodes;
 import com.windfall.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "Chat", description = "채팅방 API")
 public interface ChatRoomSpecification {
 
+  @ApiErrorCodes({NOT_FOUND_USER})
   @Operation(
       summary = "채팅방 목록 조회",
       description = """
@@ -35,6 +42,7 @@ public interface ChatRoomSpecification {
       @AuthenticationPrincipal CustomUserDetails userDetails
   );
 
+  @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_CHAT_ROOM, FORBIDDEN_CHAT_ROOM, INVALID_TRADE_STATUS_FOR_CHAT})
   @Operation(
       summary = "채팅방 상세 조회 (메타 정보 + 메시지 내용 커서 페이징)",
       description = """

--- a/src/main/java/com/windfall/api/chat/service/ChatImageService.java
+++ b/src/main/java/com/windfall/api/chat/service/ChatImageService.java
@@ -1,6 +1,7 @@
 package com.windfall.api.chat.service;
 
 import com.windfall.api.chat.dto.response.ChatImageUploadResponse;
+import com.windfall.api.user.service.UserService;
 import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
 import com.windfall.global.s3.S3Uploader;
@@ -16,10 +17,14 @@ public class ChatImageService {
 
   private static final int MAX_CHAT_IMAGE_COUNT = 5;
 
+  private final UserService userService;
   private final S3Uploader s3Uploader;
 
   @Transactional(readOnly = true)
   public List<ChatImageUploadResponse> upload(List<MultipartFile> files, Long userId) {
+
+    userService.getUserById(userId);
+
     validateChatImages(files);
 
     String dirName = "chat/images/" + userId;


### PR DESCRIPTION
## 📌 관련 이슈
- close #165 

## 📝 변경 사항
### AS-IS
- 채팅 관련 API 에서 ErrorCode 문서화가 존재하지 않았음

### TO-BE
- 채팅 관련 API에 ErrorCode 문서화

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
<img width="714" height="683" alt="image" src="https://github.com/user-attachments/assets/858c7e60-9cb9-4eec-aed1-d1b08c9dfb7f" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- Swagger에 ErrorCode만 추가한 간단한 PR 입니다!