### PR TITLE
[Feature] 유저 정보 수정 (닉네임, 프로필 이미지) API 구현

### DIFF
--- a/src/main/java/com/windfall/api/user/controller/UserInfoSpecification.java
+++ b/src/main/java/com/windfall/api/user/controller/UserInfoSpecification.java
@@ -1,18 +1,29 @@
 package com.windfall.api.user.controller;
 
+import com.windfall.api.user.dto.request.UpdateUsernameRequest;
+import com.windfall.api.user.dto.response.UpdateUserProfileImageResponse;
+import com.windfall.api.user.dto.response.UpdateUsernameResponse;
 import com.windfall.api.user.dto.response.UserInfoResponse;
 import com.windfall.api.user.dto.response.reviewlist.ReviewListResponse;
 import com.windfall.api.user.dto.response.saleshistory.BaseSalesHistoryResponse;
 import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.config.swagger.ApiErrorCodes;
+import static com.windfall.global.exception.ErrorCode.INVALID_S3_UPLOAD;
 import com.windfall.global.response.ApiResponse;
 import com.windfall.global.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "UserInfo", description = "사용자 정보 API")
 public interface UserInfoSpecification {
@@ -36,6 +47,19 @@ public interface UserInfoSpecification {
   ApiResponse<SliceResponse<ReviewListResponse>> getUserReviewList(
       @PageableDefault(page = 0, size = 10) Pageable pageable,
       @PathVariable Long userId
+  );
+
+  @ApiErrorCodes({INVALID_S3_UPLOAD})
+  @Operation(summary = "사용자 프로필 이미지 변경", description = "사용자의 프로필 이미지를 변경합니다.")
+  ApiResponse<UpdateUserProfileImageResponse> updateUserImage(
+      @RequestPart(name = "image") MultipartFile file,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  );
+
+  @Operation(summary = "사용자 프로필 이름 변경", description = "사용자의 프로필 이름을 변경합니다.")
+  ApiResponse<UpdateUsernameResponse> updateUsername(
+      @RequestBody @Valid UpdateUsernameRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
   );
 
 }

--- a/src/main/java/com/windfall/api/user/controller/UserinfoController.java
+++ b/src/main/java/com/windfall/api/user/controller/UserinfoController.java
@@ -1,25 +1,30 @@
 package com.windfall.api.user.controller;
 
-import com.windfall.api.mypage.dto.dashboard.BaseDashBoardDetails;
+import com.windfall.api.user.dto.request.UpdateUsernameRequest;
+import com.windfall.api.user.dto.response.UpdateUsernameResponse;
 import com.windfall.api.user.dto.response.UserInfoResponse;
+import com.windfall.api.user.dto.response.UpdateUserProfileImageResponse;
 import com.windfall.api.user.dto.response.reviewlist.ReviewListResponse;
 import com.windfall.api.user.dto.response.saleshistory.BaseSalesHistoryResponse;
 import com.windfall.api.user.service.UserInfoService;
-import com.windfall.domain.auction.enums.AuctionStatus;
 import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import com.windfall.global.response.SliceResponse;
-import java.time.LocalDate;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -67,4 +72,29 @@ public class UserinfoController implements UserInfoSpecification{
     return ApiResponse.ok("사용자 리뷰 목록 조회에 성공하였습니다.", response);
   }
 
+  @Override
+  @PutMapping(path = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ApiResponse<UpdateUserProfileImageResponse> updateUserImage(
+      @RequestPart(name = "image") MultipartFile file,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ){
+    Long loginId = userDetails.getUserId();
+
+    UpdateUserProfileImageResponse response = userInfoService.updateUserProfileImage(file, loginId);
+
+    return ApiResponse.ok("사용자 프로필 이미지를 수정하였습니다.", response);
+  }
+
+  @Override
+  @PutMapping("/name")
+  public ApiResponse<UpdateUsernameResponse> updateUsername(
+      @RequestBody @Valid UpdateUsernameRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ){
+    Long loginId = userDetails.getUserId();
+
+    UpdateUsernameResponse response = userInfoService.updateUsername(request, loginId);
+
+    return ApiResponse.ok("사용자 이름을 수정하였습니다.", response);
+  }
 }

--- a/src/main/java/com/windfall/api/user/controller/UserinfoController.java
+++ b/src/main/java/com/windfall/api/user/controller/UserinfoController.java
@@ -73,7 +73,7 @@ public class UserinfoController implements UserInfoSpecification{
   }
 
   @Override
-  @PutMapping(path = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PutMapping(path = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ApiResponse<UpdateUserProfileImageResponse> updateUserImage(
       @RequestPart(name = "image") MultipartFile file,
       @AuthenticationPrincipal CustomUserDetails userDetails
@@ -86,7 +86,7 @@ public class UserinfoController implements UserInfoSpecification{
   }
 
   @Override
-  @PutMapping("/name")
+  @PutMapping("/names")
   public ApiResponse<UpdateUsernameResponse> updateUsername(
       @RequestBody @Valid UpdateUsernameRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/windfall/api/user/dto/request/UpdateUsernameRequest.java
+++ b/src/main/java/com/windfall/api/user/dto/request/UpdateUsernameRequest.java
@@ -1,0 +1,15 @@
+package com.windfall.api.user.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.Length;
+
+public record UpdateUsernameRequest(
+    @NotBlank(message = "이름은 필수 항목입니다.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$", message = "영어, 숫자, 한글만 입력이 허용됩니다.")
+    @Length(min=2, max=20, message = "이름은 최소 2글자 최대 20글자만 입력이 가능합니다.")
+    String username
+) {
+
+}

--- a/src/main/java/com/windfall/api/user/dto/response/UpdateUserProfileImageResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/UpdateUserProfileImageResponse.java
@@ -1,0 +1,7 @@
+package com.windfall.api.user.dto.response;
+
+public record UpdateUserProfileImageResponse(
+    String userProfileImageUrl
+) {
+
+}

--- a/src/main/java/com/windfall/api/user/dto/response/UpdateUsernameResponse.java
+++ b/src/main/java/com/windfall/api/user/dto/response/UpdateUsernameResponse.java
@@ -1,0 +1,7 @@
+package com.windfall.api.user.dto.response;
+
+public record UpdateUsernameResponse(
+    String username
+) {
+
+}

--- a/src/main/java/com/windfall/api/user/service/UserInfoService.java
+++ b/src/main/java/com/windfall/api/user/service/UserInfoService.java
@@ -19,6 +19,8 @@ import com.windfall.domain.auction.repository.AuctionImageRepository;
 import com.windfall.domain.user.entity.User;
 import com.windfall.domain.user.repository.SalesHistoryQueryRepository;
 import com.windfall.domain.user.repository.UserInfoRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
 import com.windfall.global.response.SliceResponse;
 import com.windfall.global.s3.S3Uploader;
 import java.net.URI;
@@ -106,6 +108,8 @@ public class UserInfoService {
   public UpdateUserProfileImageResponse updateUserProfileImage(MultipartFile image, Long loginId){
     User user = userService.getUserById(loginId);
 
+    validateImage(image);
+
     String oldUrl = user.getProfileImageUrl();
     String dirName = "profile/" + loginId;
     String newUrl = s3Uploader.upload(image, dirName);
@@ -126,6 +130,12 @@ public class UserInfoService {
     user.updateUsername(request.username());
 
     return new UpdateUsernameResponse(request.username());
+  }
+
+  private void validateImage(MultipartFile files) {
+    if (files == null || files.isEmpty()) {
+      throw new ErrorException(ErrorCode.INVALID_IMAGE_FILE);
+    }
   }
 
   private String URIPathParser(String url){

--- a/src/main/java/com/windfall/domain/user/entity/User.java
+++ b/src/main/java/com/windfall/domain/user/entity/User.java
@@ -52,4 +52,12 @@ public class User extends BaseEntity {
     this.nickname = nickname;
     this.profileImageUrl = profileImageUrl;
   }
+
+  public void updateProfileImage(String url){
+    this.profileImageUrl = url;
+  }
+
+  public void updateUsername(String name){
+    this.nickname = name;
+  }
 }

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -72,6 +72,8 @@ public enum ErrorCode {
   REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "리뷰가 이미 존재합니다."),
   NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."),
 
+  //유저 이미지 검증
+  INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "이미지 파일이 유효하지 않습니다."),
 
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")

--- a/src/main/java/com/windfall/global/s3/S3Uploader.java
+++ b/src/main/java/com/windfall/global/s3/S3Uploader.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
@@ -76,5 +77,14 @@ public class S3Uploader {
       return baseUrl + key;
     }
     return baseUrl + "/" + key;
+  }
+
+  public void deleteFile(String key) {
+    DeleteObjectRequest request = DeleteObjectRequest.builder()
+        .bucket(s3Properties.getBucketName())
+        .key(key)
+        .build();
+
+    s3Client.deleteObject(request);
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #159

## 📝 변경 사항
### AS-IS
- 사용자 정보 수정 API 부재

### TO-BE
- 이미지: 새 이미지 업로드 시 S3에 저장되었던 기존 이미지 파일은 삭제
- 이름변경: 2~20글자 입력가능, 특수문자 입력 불가 (영어, 한글, 숫자만 허용)

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

### 닉네임 (userid 1 기준)
Validation
<img width="763" height="555" alt="스크린샷 2026-01-05 102325" src="https://github.com/user-attachments/assets/f1169094-67cc-472c-b65f-c93043dfa0fd" />

<img width="1260" height="600" alt="스크린샷 2026-01-05 102443" src="https://github.com/user-attachments/assets/a566bd6e-1d6e-4dbd-bd20-224e95d51857" />


<img width="503" height="554" alt="스크린샷 2026-01-05 102646" src="https://github.com/user-attachments/assets/7d844564-e515-43ad-ac7b-7708b642b2b9" />

변경 성공
<img width="762" height="576" alt="스크린샷 2026-01-05 102611" src="https://github.com/user-attachments/assets/b4b1b21e-54ae-48d4-82e6-77d477d1dd25" />


### 이미지 (userid 1 기준)
변경 성공
<img width="1481" height="658" alt="스크린샷 2026-01-05 103258" src="https://github.com/user-attachments/assets/fa3d4acb-a9a7-4cfa-ba8c-91652e96cff3" />

S3 적용 확인 및 이미지 파일 1개 유지
<img width="475" height="249" alt="스크린샷 2026-01-05 103332" src="https://github.com/user-attachments/assets/cd8b9061-9c96-426f-b839-016f1de4887c" />
<img width="525" height="233" alt="스크린샷 2026-01-05 103338" src="https://github.com/user-attachments/assets/a146733a-6a23-4b3d-a738-b3848a865378" />
<img width="1056" height="382" alt="스크린샷 2026-01-05 103357" src="https://github.com/user-attachments/assets/5bf0fd22-3349-4b99-961f-dd101afefcfb" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
이미지 업로드는 처음 해봐서 예외처리를 더 할게 있을까요?