### PR TITLE
[Feature] WebSocket CONNECT 인증 오류 세분화 + STOMP ERROR(JSON) 핸들링 적용

### DIFF
--- a/src/main/java/com/windfall/api/user/service/JwtProvider.java
+++ b/src/main/java/com/windfall/api/user/service/JwtProvider.java
@@ -93,8 +93,7 @@ public class JwtProvider {
           .getBody();
 
       Date expiration = claims.getExpiration();
-      if (expiration == null) return JwtValidationResult.INVALID; // exp 없으면 비정상 토큰
-      // parseClaimsJws 단계에서 만료면 ExpiredJwtException이 터지므로 여기까지 오면 유효
+      if (expiration == null) return JwtValidationResult.INVALID;
       return JwtValidationResult.VALID;
 
     } catch (ExpiredJwtException e) {

--- a/src/main/java/com/windfall/api/user/service/JwtProvider.java
+++ b/src/main/java/com/windfall/api/user/service/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.windfall.api.user.service;
 
+import com.windfall.domain.user.enums.JwtValidationResult;
 import com.windfall.global.exception.ErrorCode;
 import com.windfall.global.exception.ErrorException;
 import io.jsonwebtoken.Claims;
@@ -80,6 +81,26 @@ public class JwtProvider {
 
     } catch (JwtException | IllegalArgumentException e) {
       return false;
+    }
+  }
+
+  public JwtValidationResult validateTokenWithResult(String token) {
+    try {
+      Claims claims = Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(token)
+          .getBody();
+
+      Date expiration = claims.getExpiration();
+      if (expiration == null) return JwtValidationResult.INVALID; // exp 없으면 비정상 토큰
+      // parseClaimsJws 단계에서 만료면 ExpiredJwtException이 터지므로 여기까지 오면 유효
+      return JwtValidationResult.VALID;
+
+    } catch (ExpiredJwtException e) {
+      return JwtValidationResult.EXPIRED;
+    } catch (JwtException | IllegalArgumentException e) {
+      return JwtValidationResult.INVALID;
     }
   }
 

--- a/src/main/java/com/windfall/domain/user/enums/JwtValidationResult.java
+++ b/src/main/java/com/windfall/domain/user/enums/JwtValidationResult.java
@@ -1,0 +1,8 @@
+package com.windfall.domain.user.enums;
+
+public enum JwtValidationResult {
+  VALID,
+  EXPIRED,
+  INVALID
+}
+

--- a/src/main/java/com/windfall/global/config/WebSocketConfig.java
+++ b/src/main/java/com/windfall/global/config/WebSocketConfig.java
@@ -2,6 +2,7 @@ package com.windfall.global.config;
 
 import com.windfall.global.websocket.StompAuthChannelInterceptor;
 import com.windfall.global.websocket.WsHandshakeInterceptor;
+import com.windfall.global.websocket.exception.WsStompErrorHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -17,6 +18,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
   private final WsHandshakeInterceptor wsHandshakeInterceptor;
+  private final WsStompErrorHandler wsStompErrorHandler;
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -27,6 +29,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
+
+    registry.setErrorHandler(wsStompErrorHandler);
+
     // 인증 필요 endpoint
     registry.addEndpoint("/ws-stomp")
         .setAllowedOriginPatterns("*")

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -37,6 +37,12 @@ public enum ErrorCode {
   NOT_FOUND_NOTIFICATION(HttpStatus.NOT_FOUND,"존재하지 않는 알림입니다."),
   INVALID_NOTIFICATION(HttpStatus.FORBIDDEN, "해당 유저의 알림이 아닙니다."),
 
+  // WS CONNECT/인증 단계 구체 에러
+  WS_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "웹소켓 연결에 토큰이 필요합니다."),
+  WS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+  WS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+  WS_AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요한 요청입니다."),
+
   // 채팅
   NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
   FORBIDDEN_CHAT_ROOM(HttpStatus.FORBIDDEN, "채팅방에 접근할 수 있는 권한이 없습니다."),

--- a/src/main/java/com/windfall/global/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/windfall/global/websocket/StompAuthChannelInterceptor.java
@@ -35,12 +35,11 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     // 1) CONNECT
     if (StompCommand.CONNECT.equals(accessor.getCommand())) {
 
-      // 🔁 CHANGED: PUBLIC이면 토큰이 오더라도 "아예 무시"
       if ("PUBLIC".equals(endpointType)) {
         return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
       }
 
-      // ✅ SECURED만 토큰 처리
+      // SECURED만 토큰 처리
       String token = resolveToken(accessor);
 
       if (token == null) {

--- a/src/main/java/com/windfall/global/websocket/exception/WsStompErrorHandler.java
+++ b/src/main/java/com/windfall/global/websocket/exception/WsStompErrorHandler.java
@@ -1,0 +1,69 @@
+package com.windfall.global.websocket.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WsStompErrorHandler extends StompSubProtocolErrorHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+
+    Throwable root = unwrap(ex);
+
+    // ✅ 1) 우리 커스텀 에러면: ErrorCode 기반으로 JSON 내려줌
+    if (root instanceof ErrorException ee) {
+      ErrorCode code = ee.getErrorCode();
+      WsErrorEvent payload = WsErrorEvent.of(code.name(), code.getMessage());
+      return buildErrorFrame(payload);
+    }
+
+    // ✅ 2) 그 외는 UNKNOWN_ERROR
+    log.warn("WS processing error (unhandled): {}", root.toString(), root);
+    WsErrorEvent payload = WsErrorEvent.of(ErrorCode.UNKNOWN_ERROR.name(), "웹소켓 처리 중 오류가 발생했습니다.");
+    return buildErrorFrame(payload);
+  }
+
+  private Message<byte[]> buildErrorFrame(WsErrorEvent payload) {
+    StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.ERROR);
+    headers.setLeaveMutable(true);
+    headers.setMessage(payload.message()); // STOMP 표준 message 헤더(보조)
+
+    try {
+      String json = objectMapper.writeValueAsString(payload);
+      return MessageBuilder.createMessage(json.getBytes(StandardCharsets.UTF_8), headers.getMessageHeaders());
+    } catch (JsonProcessingException e) {
+      // JSON 변환 실패 시 최소 메시지라도 내려줌
+      String fallback = "{\"code\":\"" + payload.code() + "\",\"message\":\"" + payload.message() + "\"}";
+      return MessageBuilder.createMessage(fallback.getBytes(StandardCharsets.UTF_8), headers.getMessageHeaders());
+    }
+  }
+
+  private Throwable unwrap(Throwable ex) {
+    // Spring WS 쪽에서 MessageDeliveryException으로 감싸지는 케이스가 많아서 벗김
+    if (ex instanceof MessageDeliveryException mde && mde.getCause() != null) {
+      return unwrap(mde.getCause());
+    }
+    if (ex.getCause() != null && ex.getCause() != ex) {
+      // 2~3겹 더 감싸질 수도 있으니 한 번 더 안전하게
+      return ex.getCause();
+    }
+    return ex;
+  }
+}

--- a/src/main/java/com/windfall/global/websocket/exception/WsStompErrorHandler.java
+++ b/src/main/java/com/windfall/global/websocket/exception/WsStompErrorHandler.java
@@ -27,14 +27,14 @@ public class WsStompErrorHandler extends StompSubProtocolErrorHandler {
 
     Throwable root = unwrap(ex);
 
-    // ✅ 1) 우리 커스텀 에러면: ErrorCode 기반으로 JSON 내려줌
+    // 1) 우리 커스텀 에러면: ErrorCode 기반으로 JSON 내려줌
     if (root instanceof ErrorException ee) {
       ErrorCode code = ee.getErrorCode();
       WsErrorEvent payload = WsErrorEvent.of(code.name(), code.getMessage());
       return buildErrorFrame(payload);
     }
 
-    // ✅ 2) 그 외는 UNKNOWN_ERROR
+    // 2) 그 외는 UNKNOWN_ERROR
     log.warn("WS processing error (unhandled): {}", root.toString(), root);
     WsErrorEvent payload = WsErrorEvent.of(ErrorCode.UNKNOWN_ERROR.name(), "웹소켓 처리 중 오류가 발생했습니다.");
     return buildErrorFrame(payload);
@@ -43,26 +43,23 @@ public class WsStompErrorHandler extends StompSubProtocolErrorHandler {
   private Message<byte[]> buildErrorFrame(WsErrorEvent payload) {
     StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.ERROR);
     headers.setLeaveMutable(true);
-    headers.setMessage(payload.message()); // STOMP 표준 message 헤더(보조)
+    headers.setMessage(payload.message());
 
     try {
       String json = objectMapper.writeValueAsString(payload);
       return MessageBuilder.createMessage(json.getBytes(StandardCharsets.UTF_8), headers.getMessageHeaders());
     } catch (JsonProcessingException e) {
-      // JSON 변환 실패 시 최소 메시지라도 내려줌
       String fallback = "{\"code\":\"" + payload.code() + "\",\"message\":\"" + payload.message() + "\"}";
       return MessageBuilder.createMessage(fallback.getBytes(StandardCharsets.UTF_8), headers.getMessageHeaders());
     }
   }
 
   private Throwable unwrap(Throwable ex) {
-    // Spring WS 쪽에서 MessageDeliveryException으로 감싸지는 케이스가 많아서 벗김
     if (ex instanceof MessageDeliveryException mde && mde.getCause() != null) {
       return unwrap(mde.getCause());
     }
     if (ex.getCause() != null && ex.getCause() != ex) {
       // 2~3겹 더 감싸질 수도 있으니 한 번 더 안전하게
-      return ex.getCause();
     }
     return ex;
   }

--- a/src/main/resources/static/ws-connect-test.html
+++ b/src/main/resources/static/ws-connect-test.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <title>Windfall WS CONNECT Error Test</title>
+
+  <!-- SockJS + StompJS (CDN) -->
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 980px; margin: 20px auto; }
+    input, button, select { padding: 8px; margin: 4px; }
+    .row { margin: 8px 0; }
+    pre {
+      background: #111;
+      color: #0f0;
+      padding: 16px;
+      height: 560px;
+      overflow: auto;
+      font-size: 13px;
+      line-height: 1.45;
+      white-space: pre-wrap;
+    }
+    .hint { color: #444; font-size: 13px; margin-top: 4px; }
+    .badge { display:inline-block; padding: 2px 6px; border-radius: 6px; background:#eee; font-size: 12px;}
+  </style>
+</head>
+<body>
+<h2>WS CONNECT Error Test <span class="badge">SockJS + StompJS</span></h2>
+
+<div class="row">
+  <label>Endpoint: </label>
+  <select id="endpoint">
+    <option value="/ws-stomp">/ws-stomp (SECURED)</option>
+    <option value="/ws-stomp-public">/ws-stomp-public (PUBLIC)</option>
+  </select>
+
+  <label>JWT (선택): </label>
+  <input id="token" style="width: 520px" placeholder="Bearer 없이 토큰만 넣어도 됨" />
+
+  <button onclick="connect()">Connect</button>
+  <button onclick="disconnect()">Disconnect</button>
+  <button onclick="clearLog()">Clear</button>
+
+  <div class="hint">
+    ✅ 목표: CONNECT 단계에서 서버가 STOMP ERROR(JSON)를 내려주는지 확인<br/>
+    - SECURED(/ws-stomp): 토큰 없음 → <b>WS_TOKEN_MISSING</b><br/>
+    - 만료 토큰 → <b>WS_TOKEN_EXPIRED</b> / 무효 토큰 → <b>WS_TOKEN_INVALID</b><br/>
+    - PUBLIC(/ws-stomp-public): 토큰 없이도 연결 OK (단, 토큰을 “보내면” 검증하다가 실패할 수 있음)
+  </div>
+</div>
+
+<hr/>
+
+<div class="row">
+  <label>Connect Test Presets:</label>
+  <button onclick="setToken('')">토큰 비우기</button>
+  <button onclick="setToken('abc.def.ghi')">무효 토큰(가짜)</button>
+</div>
+
+<div class="row">
+  <label>After CONNECT (옵션)</label>
+  <input id="roomId" value="1" style="width: 80px" />
+  <button onclick="subscribeChat()">채팅 구독(옵션)</button>
+</div>
+
+<h3>Logs</h3>
+<pre id="log"></pre>
+
+<script>
+  let stompClient = null;
+  let sock = null;
+
+  function log(msg) {
+    const el = document.getElementById("log");
+    el.textContent += msg + "\n";
+    el.scrollTop = el.scrollHeight;
+    console.log(msg);
+  }
+
+  function clearLog() {
+    document.getElementById("log").textContent = "";
+  }
+
+  function setToken(v) {
+    document.getElementById("token").value = v;
+  }
+
+  function connect() {
+    const endpoint = document.getElementById("endpoint").value;
+    const token = document.getElementById("token").value.trim();
+
+    log("------------------------------------------------------------");
+    log(`▶ CONNECT TRY endpoint=${endpoint}`);
+    log(`▶ tokenProvided=${token ? "YES" : "NO"}`);
+
+    sock = new SockJS(endpoint);
+    stompClient = Stomp.over(sock);
+
+    // stomp 내부 debug 로그(원하면 끄기)
+    stompClient.debug = (str) => log("[stomp] " + str);
+
+    // ✅ 핵심: 서버가 STOMP ERROR 프레임을 보내면 여기로 들어온다.
+    stompClient.onerror = (frame) => {
+      log("🚨 [STOMP ERROR FRAME RECEIVED]");
+      try {
+        log("headers=" + JSON.stringify(frame.headers));
+      } catch (e) {}
+
+      // frame.body에 우리가 만든 JSON(WsErrorEvent)이 들어온다.
+      if (frame.body) {
+        log("body(raw)=" + frame.body);
+        try {
+          const obj = JSON.parse(frame.body);
+          log(`body(parsed)=code=${obj.code}, message=${obj.message}, timestamp=${obj.timestamp}`);
+        } catch (e) {
+          log("body(parse fail)=" + e.message);
+        }
+      } else {
+        log("body=<empty>");
+      }
+    };
+
+    // WebSocket close 확인 (SockJS여도 close 이벤트는 발생)
+    sock.onclose = (e) => {
+      log(`🔌 [SOCKJS CLOSED] code=${e?.code}, reason=${e?.reason}`);
+    };
+
+    const headers = {};
+    if (token) headers["Authorization"] = token.startsWith("Bearer ") ? token : ("Bearer " + token);
+
+    stompClient.connect(headers, (frame) => {
+      log("✅ CONNECTED OK");
+      log(String(frame));
+
+      // 연결 성공한 경우에만 아래는 의미가 있음
+      // (CONNECT 실패면 여기로 못 들어옴)
+      log("✅ TIP: 이제 구독/전송 테스트도 가능");
+    }, (err) => {
+      // connect error callback은 라이브러리/환경에 따라 메시지가 뭉뚱그려질 수 있음
+      log("❌ CONNECT ERROR CALLBACK");
+      try {
+        log("err=" + JSON.stringify(err));
+      } catch (e) {
+        log("err=" + String(err));
+      }
+      log("❗ CONNECT 실패 상세는 위의 [STOMP ERROR FRAME RECEIVED] 로그를 확인하세요.");
+    });
+  }
+
+  function disconnect() {
+    if (stompClient) {
+      stompClient.disconnect(() => log("👋 DISCONNECTED"));
+    }
+    stompClient = null;
+    sock = null;
+  }
+
+  // 연결 성공 후에만(옵션) 채팅 구독 붙여보기
+  function subscribeChat() {
+    if (!stompClient) return alert("먼저 Connect 하세요");
+    const roomId = document.getElementById("roomId").value.trim();
+    if (!roomId) return alert("roomId를 입력하세요");
+
+    log(`📌 subscribe /topic/chat.rooms.${roomId}`);
+    stompClient.subscribe(`/topic/chat.rooms.${roomId}`, (message) => {
+      log("📩 [ROOM TOPIC] " + message.body);
+    });
+
+    log("📌 subscribe /user/queue/chat.rooms");
+    stompClient.subscribe(`/user/queue/chat.rooms`, (message) => {
+      log("🧾 [MY ROOMS QUEUE] " + message.body);
+    });
+
+    log("📌 subscribe /user/queue/errors");
+    stompClient.subscribe(`/user/queue/errors`, (message) => {
+      log("🚨 [WS QUEUE ERROR] " + message.body);
+    });
+
+    log("✅ SUBSCRIBED");
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 관련 이슈
- close #176 

## 📝 변경 사항
### AS-IS
* WebSocket CONNECT 단계에서 토큰 누락/만료/무효 등 인증 오류가 발생해도 프론트에서는

  * `Failed to send message to ExecutorSubscribableChannel[clientInboundChannel]`
  * 혹은 일반적인 “INVALID_TOKEN” 수준으로만 인지되어 **에러 원인을 구체적으로 분기 처리하기 어려움**
* `@MessageExceptionHandler` 기반의 `WsExceptionHandler`는 **Principal이 존재하는 상태(연결 이후)** 에 주로 동작하여,

  * CONNECT 단계처럼 Principal이 없는 상태에서 발생하는 예외는 사용자 큐(`/user/queue/errors`)로 전달 불가

### TO-BE
* CONNECT 단계 인증 실패 사유를 구체적으로 분리

  * `WS_TOKEN_MISSING` (토큰 없음)
  * `WS_TOKEN_EXPIRED` (만료)
  * `WS_TOKEN_INVALID` (무효/위변조)
  * `WS_AUTH_REQUIRED` (인증 필수 destination 접근)
* `JwtValidationResult` + `JwtProvider.validateTokenWithResult()`로 JWT 상태를 명확히 판단
* `WsStompErrorHandler(StompSubProtocolErrorHandler)`를 도입하여 CONNECT 단계 예외도

  * **STOMP ERROR 프레임(JSON)** 으로 일관된 에러 payload 반환
* 결과적으로 프론트는 CONNECT 단계에서 에러를 **code/message 기반으로 안정적으로 분기 처리** 가능

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- /ws-stomp(Secured) 요청시 토큰 x
<img width="1037" height="858" alt="image" src="https://github.com/user-attachments/assets/ec16f090-3579-4f6b-a6eb-6c694a3bcb3f" />

- /ws-stomp(Secured) 요청시 틀린 토큰
<img width="979" height="280" alt="image" src="https://github.com/user-attachments/assets/73dbb05b-9b7e-412c-9aed-05a9cbaf3509" />

- /ws-stomp(Secured) 요청시 유효한 토큰
<img width="458" height="309" alt="image" src="https://github.com/user-attachments/assets/d2b2f7d3-e67b-4082-bf59-2443a6d9daea" />



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- CONNECT 단계 예외 처리를 WsExceptionHandler(@MessageExceptionHandler)가 아닌
WsStompErrorHandler(StompSubProtocolErrorHandler)로 분리한 구조가 적절한지 확인 부탁드립니다.

- StompAuthChannelInterceptor에서 CONNECT 시점에 토큰을 검증하고,
만료/무효/누락을 ErrorCode로 세분화하여 던지는 흐름이 의도대로 동작하는지 함께 봐주시면 좋겠습니다.

- PUBLIC endpoint에서 토큰을 선택적으로 허용하는 정책이 현재 요구사항과 일치하는지 검토 부탁드립니다.


