### PR TITLE
[Feature] 채팅 실시간 읽음 처리(Read Receipt) 이벤트 브로드캐스트 구현

### DIFF
--- a/src/main/java/com/windfall/api/chat/dto/websocket/ChatReadEvent.java
+++ b/src/main/java/com/windfall/api/chat/dto/websocket/ChatReadEvent.java
@@ -1,0 +1,14 @@
+package com.windfall.api.chat.dto.websocket;
+
+import java.time.LocalDateTime;
+
+public record ChatReadEvent(
+    Long chatRoomId,
+    Long readerId,
+    Long lastReadMessageId,
+    LocalDateTime readAt
+) {
+  public static ChatReadEvent of(Long chatRoomId, Long readerId, Long lastReadMessageId) {
+    return new ChatReadEvent(chatRoomId, readerId, lastReadMessageId, LocalDateTime.now());
+  }
+}

--- a/src/main/java/com/windfall/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/windfall/domain/chat/repository/ChatMessageRepository.java
@@ -66,4 +66,12 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
       @Param("chatRoomId") Long chatRoomId,
       @Param("userId") Long userId
   );
+
+  @Query("""
+      select max(cm.id)
+      from ChatMessage cm
+      where cm.chatRoom.id = :chatRoomId
+      """)
+  Long findMaxMessageId(@Param("chatRoomId") Long chatRoomId);
+
 }

--- a/src/main/resources/static/test-chat.html
+++ b/src/main/resources/static/test-chat.html
@@ -98,6 +98,10 @@
         log("🚨 [WS ERROR] " + message.body);
       });
 
+      stompClient.subscribe(`/topic/chat.read.${roomId}`, (message) => {
+        log("👁️ [READ EVENT] " + message.body);
+      });
+
       log("✅ SUBSCRIBED to room + my queue");
     }, (err) => {
       log("❌ CONNECT ERROR: " + JSON.stringify(err));


### PR DESCRIPTION
## 📌 관련 이슈
- close #179 

## 📝 변경 사항
### AS-IS
* 사용자가 채팅방에서 `markAsRead()`를 호출하면 DB에서 상대 메시지 `isRead=true` 업데이트만 수행
* 읽음 처리 결과가 “내 채팅방 목록(unread reset)”에는 반영되지만, **상대방(발신자)에게는 읽음 상태 변화가 실시간으로 전달되지 않음**
* 따라서 발신자 말풍선의 “읽음 표시”는 실시간으로 갱신될 수 없고, 화면 재진입/재조회 시에만 간접 반영 가능

### TO-BE
* `markAsRead()` 이후 **읽음 처리(updated > 0) 발생 시** `/topic/chat.read.{chatRoomId}`로 read receipt 이벤트를 브로드캐스트
* 이벤트에 `lastReadMessageId`를 포함하여, 프론트에서

  * `readerId != myId` 이고
  * `senderId == myId` 이며
  * `messageId <= lastReadMessageId`
    인 메시지들을 읽음 처리 UI로 즉시 갱신 가능
* 결과적으로 “상대가 읽었는지”가 실시간으로 반영되어 UX 개선

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 읽음 이벤트가 상대에게 실시간으로 보이는지(창 A, 창 B 모두 동일한 내용 확인)
<img width="890" height="322" alt="image" src="https://github.com/user-attachments/assets/5146bc51-b05c-4926-8da3-89f3ffd75d96" />

- 연속으로 메시지 여러 개 보낸 후 읽었을 때의 lastReadMessageId 일치 확인 (상대방 측에서 Mark As Read)
<img width="2868" height="234" alt="image" src="https://github.com/user-attachments/assets/18c03bbc-68b2-4084-9c44-1139be576670" />
<img width="889" height="312" alt="image" src="https://github.com/user-attachments/assets/39ef42e9-70fc-4865-b1a7-fb0c542c4147" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 기존 markAsRead 로직에 실시간 읽음 처리 기능만 추가한 PR 입니다.