### PR TITLE
[Feature] 구매 확정 API 구현

### DIFF
--- a/src/main/java/com/windfall/api/trade/controller/TradeController.java
+++ b/src/main/java/com/windfall/api/trade/controller/TradeController.java
@@ -1,10 +1,33 @@
 package com.windfall.api.trade.controller;
 
+import com.windfall.api.trade.service.TradeService;
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class TradeController {
+@RequestMapping("/api/v1/trade")
+public class TradeController implements TradeSpecification{
+
+  private final TradeService tradeService;
+
+  @Override
+  @PutMapping("/{tradeId}/confirm")
+  public ApiResponse<Void> purchaseConfirmTrade(
+      @PathVariable Long tradeId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ){
+    Long userId = userDetails.getUserId();
+
+    tradeService.purchaseConfirmTrade(userId, tradeId);
+
+    return ApiResponse.ok("해당 경매상품의 구매를 확정하였습니다.", null);
+  }
 
 }

--- a/src/main/java/com/windfall/api/trade/controller/TradeController.java
+++ b/src/main/java/com/windfall/api/trade/controller/TradeController.java
@@ -5,20 +5,20 @@ import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/trade")
+@RequestMapping("/api/v1/trades")
 public class TradeController implements TradeSpecification{
 
   private final TradeService tradeService;
 
   @Override
-  @PutMapping("/{tradeId}/confirm")
+  @PatchMapping("/{tradeId}/confirm")
   public ApiResponse<Void> purchaseConfirmTrade(
       @PathVariable Long tradeId,
       @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/windfall/api/trade/controller/TradeSpecification.java
+++ b/src/main/java/com/windfall/api/trade/controller/TradeSpecification.java
@@ -1,0 +1,22 @@
+package com.windfall.api.trade.controller;
+
+import com.windfall.domain.user.entity.CustomUserDetails;
+import com.windfall.global.config.swagger.ApiErrorCodes;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_TRADE;
+import static com.windfall.global.exception.ErrorCode.NOT_PAYMENT_COMPLETED_TRADE;
+import static com.windfall.global.exception.ErrorCode.NOT_MATCHED_BUYER_ID;
+import com.windfall.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Trade", description = "거래 API")
+public interface TradeSpecification {
+
+  @ApiErrorCodes({NOT_FOUND_TRADE, NOT_PAYMENT_COMPLETED_TRADE, NOT_MATCHED_BUYER_ID})
+  ApiResponse<Void> purchaseConfirmTrade(
+      @PathVariable Long tradeId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  );
+
+}

--- a/src/main/java/com/windfall/api/trade/service/TradeService.java
+++ b/src/main/java/com/windfall/api/trade/service/TradeService.java
@@ -18,8 +18,7 @@ public class TradeService {
   @Transactional
   public void purchaseConfirmTrade(Long userId, Long tradeId){
 
-    Trade trade = tradeRepository.findById(tradeId).orElseThrow(
-        () -> new ErrorException(ErrorCode.NOT_FOUND_TRADE));
+    Trade trade = validateTrade(tradeId);
 
     //payment가 있는지
     isPaymentCompleted(trade.getStatus());
@@ -41,6 +40,11 @@ public class TradeService {
     if(!buyerId.equals(userId)){
       throw new ErrorException(ErrorCode.NOT_MATCHED_BUYER_ID);
     }
+  }
+
+  private Trade validateTrade(Long tradeId){
+    return tradeRepository.findById(tradeId).orElseThrow(
+        () -> new ErrorException(ErrorCode.NOT_FOUND_TRADE));
   }
 
 }

--- a/src/main/java/com/windfall/api/trade/service/TradeService.java
+++ b/src/main/java/com/windfall/api/trade/service/TradeService.java
@@ -1,10 +1,46 @@
 package com.windfall.api.trade.service;
 
+import com.windfall.domain.trade.entity.Trade;
+import com.windfall.domain.trade.enums.TradeStatus;
+import com.windfall.domain.trade.repository.TradeRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TradeService {
+
+  private final TradeRepository tradeRepository;
+
+  @Transactional
+  public void purchaseConfirmTrade(Long userId, Long tradeId){
+
+    Trade trade = tradeRepository.findById(tradeId).orElseThrow(
+        () -> new ErrorException(ErrorCode.NOT_FOUND_TRADE));
+
+    //payment가 있는지
+    isPaymentCompleted(trade.getStatus());
+
+    //tradeid에 해당하는 buyerid가 유효한지 검증
+    validateUser(trade.getBuyerId(), userId);
+
+    //변경
+    trade.changeStatus(TradeStatus.PURCHASE_CONFIRMED);
+  }
+
+  private void isPaymentCompleted(TradeStatus status){
+    if(!status.equals(TradeStatus.PAYMENT_COMPLETED)){
+      throw new ErrorException(ErrorCode.NOT_PAYMENT_COMPLETED_TRADE);
+    }
+  }
+
+  private void validateUser(Long buyerId, Long userId){
+    if(!buyerId.equals(userId)){
+      throw new ErrorException(ErrorCode.NOT_MATCHED_BUYER_ID);
+    }
+  }
 
 }

--- a/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
@@ -7,6 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
   Optional<Trade> findByAuction(Auction auction);
-
-  Optional<Trade> findById(Long id);
 }

--- a/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/windfall/domain/trade/repository/TradeRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
   Optional<Trade> findByAuction(Auction auction);
+
+  Optional<Trade> findById(Long id);
 }

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -71,6 +71,7 @@ public enum ErrorCode {
 
   //거래
   NOT_FOUND_TRADE(HttpStatus.NOT_FOUND, "존재하지 않는 거래입니다."),
+  NOT_PAYMENT_COMPLETED_TRADE(HttpStatus.BAD_REQUEST, "결제가 완료된 거래가 아닙니다."),
 
   //리뷰
   NOT_MATCHED_BUYER_ID(HttpStatus.BAD_REQUEST, "이 거래는 사용자의 거래가 아닙니다."),


### PR DESCRIPTION
## 📌 관련 이슈
- close #181 

## 📝 변경 사항
### AS-IS
- 마이페이지에 구매를 확정하는 API가 없었음

### TO-BE
- 검증: 결제가 완료된 거래인지
- 검증2: (검증1이 검증된 상태에서) 거래의 구매자가 로그인한 사용자와 같은지
- 두 검증 통과 시 구매 확정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

### 검증 실패 시 에러들
<img width="851" height="797" alt="image" src="https://github.com/user-attachments/assets/04aa784b-a752-49e4-a699-1c0c5e4a3d39" />
<img width="554" height="792" alt="image" src="https://github.com/user-attachments/assets/3cffbc9d-dbfd-4883-b526-b8e669f69cf5" />

### 성공 시
<img width="823" height="479" alt="image" src="https://github.com/user-attachments/assets/e71654ab-e143-4bd2-b37d-8a3822709007" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
검증이 충분한지 봐주시면 감사하겠습니다!