### PR TITLE
[Feature] 경매 종료(낙찰/유찰) 알림 기능 추가

### DIFF
--- a/src/main/java/com/windfall/api/notification/service/SseService.java
+++ b/src/main/java/com/windfall/api/notification/service/SseService.java
@@ -99,6 +99,96 @@ public class SseService {
     saveAndSend(userId, "auctionStartAlert", notification);
   }
 
+  @Async("socketTaskExecutor")
+  @Transactional
+  public void sendAuctionFailedToSeller(Long sellerId, Long auctionId, String auctionTitle) {
+    sendAuctionFailed(
+        sellerId,
+        auctionId,
+        auctionTitle,
+        NotificationType.AUCTION_FAILED_SELLER,
+        "auctionFailedSeller"
+    );
+  }
+
+  @Async("socketTaskExecutor")
+  @Transactional
+  public void sendAuctionFailedToSubscriber(Long userId, Long auctionId, String auctionTitle) {
+    sendAuctionFailed(
+        userId,
+        auctionId,
+        auctionTitle,
+        NotificationType.AUCTION_FAILED_SUBSCRIBER,
+        "auctionFailedSubscriber"
+    );
+  }
+
+  @Async("socketTaskExecutor")
+  @Transactional
+  public void sendAuctionSuccessToSeller(Long sellerId, Long auctionId, String auctionTitle) {
+    sendAuctionSuccess(
+        sellerId,
+        auctionId,
+        auctionTitle,
+        NotificationType.SALE_SUCCESS_SELLER,
+        "auctionSuccessSeller"
+    );
+  }
+
+  @Async("socketTaskExecutor")
+  @Transactional
+  public void sendAuctionSuccessToSubscriber(Long userId, Long auctionId, String auctionTitle) {
+    sendAuctionSuccess(
+        userId,
+        auctionId,
+        auctionTitle,
+        NotificationType.SALE_SUCCESS_SUBSCRIBER,
+        "auctionSuccessSubscriber"
+    );
+  }
+
+  private void sendAuctionFailed(
+      Long userId,
+      Long auctionId,
+      String auctionTitle,
+      NotificationType type,
+      String sseEventName
+  ) {
+    User user = getUserOrThrow(userId);
+
+    Notification notification = Notification.create(
+        user,
+        "경매 유찰 알림",
+        "'" + auctionTitle + "' 경매가 유찰되었습니다.",
+        false,
+        type,
+        auctionId
+    );
+
+    saveAndSend(userId, sseEventName, notification);
+  }
+
+  private void sendAuctionSuccess(
+      Long userId,
+      Long auctionId,
+      String auctionTitle,
+      NotificationType type,
+      String sseEventName
+  ) {
+    User user = getUserOrThrow(userId);
+
+    Notification notification = Notification.create(
+        user,
+        "경매 낙찰 알림",
+        "'" + auctionTitle + "' 경매가 낙찰되었습니다.",
+        false,
+        type,
+        auctionId
+    );
+
+    saveAndSend(userId, sseEventName, notification);
+  }
+
   private User getUserOrThrow(Long userId) {
     return userRepository.findById(userId)
         .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_USER));


### PR DESCRIPTION
## 📌 관련 이슈
- close #119

## 📝 변경 사항
### AS-IS
- 경매 종료 알림 기능 부재

### TO-BE
- 판매자&알림 설정 유저를 위한 유찰/낙찰 알림 기능 추가
  - Stop Loss 도달 시 유찰 알림 발동
  - 경매 상태가 낙찰로 변경되면 낙찰 알림 발동
  - 참고: 알림 설정 안 했으면 구매자(낙찰자)에겐 따로 알림 안 감
- 중복되는 코드를 메서드로 분리하여 리팩토링
  - `Consumer<T>`, `BiConsumer<T, U>` 사용
  - `AuctionStateService` 👉 `notifySubscribers()`, `notifySeller()`
  - `SseService` 👉 `sendNotification()`

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 중복되는 코드를 리팩토링을 하면서 경매 시작, 가격 하락 부분도 같이 하였습니다. 이 부분 확인 부탁드립니다
- 테스트 코드까지 작성하려고 했는데,,, 추후에 하겠습니다..!