### PR TITLE
[Feature] 최근 본 내역 삭제 API 구현

### DIFF
--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/BaseRecentViewList.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/BaseRecentViewList.java
@@ -14,6 +14,9 @@ import lombok.Getter;
 )
 public abstract class BaseRecentViewList {
 
+  @Schema(description = "최근 본 내역 id")
+  private final Long recentViewId;
+
   @Schema(description = "경매 상태")
   private final String status;
 
@@ -32,8 +35,9 @@ public abstract class BaseRecentViewList {
   @Schema(description = "경매 시작일")
   private final LocalDate startedAt;
 
-  public BaseRecentViewList(String status, Long auctionId, String title, String auctionImageUrl,
-      int startPrice, LocalDate startedAt) {
+  public BaseRecentViewList(Long recentViewId, String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt) {
+    this.recentViewId = recentViewId;
     this.status = status;
     this.auctionId = auctionId;
     this.title = title;

--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/CompletedRecentViewListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/CompletedRecentViewListResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 
 @Getter
 @JsonPropertyOrder({
+    "recentViewId",
     "status",
     "auctionId",
     "title",
@@ -32,10 +33,11 @@ public class CompletedRecentViewListResponse extends BaseRecentViewList{
   private final String tradeStatus;
 
   @Builder
-  public CompletedRecentViewListResponse(String status, Long auctionId, String title,
-      String auctionImageUrl, int startPrice, LocalDate startedAt, int discountPercent,
+  public CompletedRecentViewListResponse(Long recentViewId, String status, Long auctionId,
+      String title, String auctionImageUrl, int startPrice, LocalDate startedAt,
+      int discountPercent,
       int endPrice, String tradeStatus) {
-    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    super(recentViewId, status, auctionId, title, auctionImageUrl, startPrice, startedAt);
     this.discountPercent = discountPercent;
     this.endPrice = endPrice;
     this.tradeStatus = tradeStatus;
@@ -43,6 +45,7 @@ public class CompletedRecentViewListResponse extends BaseRecentViewList{
 
   public static CompletedRecentViewListResponse from(Tuple tuple){
     return CompletedRecentViewListResponse.builder()
+        .recentViewId(tuple.get("recentViewId", Long.class))
         .status(tuple.get("status", String.class))
         .auctionId(tuple.get("auctionId", Long.class))
         .title(tuple.get("title", String.class))

--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/ProcessingRecentViewListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/ProcessingRecentViewListResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 
 @Getter
 @JsonPropertyOrder({
+    "recentViewId",
     "status",
     "auctionId",
     "title",
@@ -28,16 +29,17 @@ public class ProcessingRecentViewListResponse extends BaseRecentViewList{
   int discountPercent;
 
   @Builder
-  public ProcessingRecentViewListResponse(String status, Long auctionId, String title,
-      String auctionImageUrl, int startPrice, LocalDate startedAt, int currentPrice,
+  public ProcessingRecentViewListResponse(Long recentViewId, String status, Long auctionId,
+      String title, String auctionImageUrl, int startPrice, LocalDate startedAt, int currentPrice,
       int discountPercent) {
-    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+    super(recentViewId, status, auctionId, title, auctionImageUrl, startPrice, startedAt);
     this.currentPrice = currentPrice;
     this.discountPercent = discountPercent;
   }
 
   public static ProcessingRecentViewListResponse from(Tuple tuple){
     return ProcessingRecentViewListResponse.builder()
+        .recentViewId(tuple.get("recentViewId", Long.class))
         .status(tuple.get("status", String.class))
         .auctionId(tuple.get("auctionId", Long.class))
         .title(tuple.get("title", String.class))

--- a/src/main/java/com/windfall/api/mypage/dto/recentviewlist/RecentViewListResponse.java
+++ b/src/main/java/com/windfall/api/mypage/dto/recentviewlist/RecentViewListResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 
 @Getter
 @JsonPropertyOrder({
+    "recentViewId",
     "status",
     "auctionId",
     "title",
@@ -19,13 +20,14 @@ import lombok.Getter;
 public class RecentViewListResponse extends BaseRecentViewList{
 
   @Builder
-  public RecentViewListResponse(String status, Long auctionId, String title, String auctionImageUrl,
-      int startPrice, LocalDate startedAt) {
-    super(status, auctionId, title, auctionImageUrl, startPrice, startedAt);
+  public RecentViewListResponse(Long recentViewId, String status, Long auctionId, String title,
+      String auctionImageUrl, int startPrice, LocalDate startedAt) {
+    super(recentViewId, status, auctionId, title, auctionImageUrl, startPrice, startedAt);
   }
 
   public static RecentViewListResponse from(Tuple tuple){
     return RecentViewListResponse.builder()
+        .recentViewId(tuple.get("recentViewId", Long.class))
         .status(tuple.get("status", String.class))
         .auctionId(tuple.get("auctionId", Long.class))
         .title(tuple.get("title", String.class))

--- a/src/main/java/com/windfall/api/recentview/controller/RecentViewController.java
+++ b/src/main/java/com/windfall/api/recentview/controller/RecentViewController.java
@@ -5,6 +5,7 @@ import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +29,19 @@ public class RecentViewController implements RecentViewSpecification {
     recentViewService.record(auctionId, userId);
 
     return ApiResponse.ok("최근 본 목록이 업데이트 되었습니다.", null);
+  }
+
+  @Override
+  @DeleteMapping("/{recentViewId}")
+  public ApiResponse<Void> deleteRecentView(
+      @PathVariable Long recentViewId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ){
+
+    Long userId = userDetails.getUserId();
+    recentViewService.deleteView(recentViewId, userId);
+
+    return ApiResponse.ok("최근 본 목록을 삭제하였습니다.", null);
   }
 
 }

--- a/src/main/java/com/windfall/api/recentview/controller/RecentViewSpecification.java
+++ b/src/main/java/com/windfall/api/recentview/controller/RecentViewSpecification.java
@@ -16,5 +16,9 @@ public interface RecentViewSpecification {
       @AuthenticationPrincipal CustomUserDetails userDetails
   );
 
-
+  @Operation(summary = "최근 본 경매내역 삭제", description = "최근 본 경매 내역을 삭제합니다. (마이페이지에서 사용됩니다.)")
+  ApiResponse<Void> deleteRecentView(
+      @PathVariable Long recentViewId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  );
 }

--- a/src/main/java/com/windfall/api/recentview/service/RecentViewService.java
+++ b/src/main/java/com/windfall/api/recentview/service/RecentViewService.java
@@ -36,6 +36,28 @@ public class RecentViewService {
     }
   }
 
+  @Transactional
+  public void deleteView(Long recentViewId, Long userId){
+    //최근 본 내역 id가 유효한지 검증
+    RecentView recentView = validateRecentView(recentViewId);
+
+    //유저 검증
+    validateUser(recentView.getUserId(), userId);
+
+    //삭제
+    recentViewRepository.delete(recentView);
+  }
+
+  private RecentView validateRecentView(Long recentViewId){
+    return recentViewRepository.findById(recentViewId).orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_RECENT_VIEW));
+  }
+
+  private void validateUser(Long recentViewUserId, Long userId){
+    if(!recentViewUserId.equals(userId)){
+      throw new ErrorException(ErrorCode.INVALID_RECENT_VIEW_USERID);
+    }
+  }
+
   private void removeLastView(Long userId){
     int count = recentViewRepository.countByUserId(userId);
 

--- a/src/main/java/com/windfall/domain/mypage/repository/RecentViewListQueryRepository.java
+++ b/src/main/java/com/windfall/domain/mypage/repository/RecentViewListQueryRepository.java
@@ -26,6 +26,7 @@ public interface RecentViewListQueryRepository extends JpaRepository<Auction, Lo
 
   @Query(value = """
   SELECT
+  rv.id AS recentViewId,
   a.status AS status, -- 경매 상태 (일반, 취소)
   a.id AS auctionId, -- 경매 아이디
   a.title AS title, -- 경매 이름 (상품 이름)
@@ -47,6 +48,7 @@ public interface RecentViewListQueryRepository extends JpaRepository<Auction, Lo
 
   @Query(value = """
   SELECT
+  rv.id AS recentViewId,
   a.status AS status, -- 경매 상태 (완료)
   a.id AS auctionId, -- 경매 아이디
   a.title AS title, -- 경매 이름 (상품 이름)
@@ -72,6 +74,7 @@ public interface RecentViewListQueryRepository extends JpaRepository<Auction, Lo
 
   @Query(value = """
   SELECT
+  rv.id AS recentViewId,
   a.status AS status, -- 경매 상태 (진행 중, 유찰)
   a.id AS auctionId, -- 경매 아이디
   a.title AS title, -- 경매 이름 (상품 이름)

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -82,6 +82,10 @@ public enum ErrorCode {
   //유저 이미지 검증
   INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "이미지 파일이 유효하지 않습니다."),
 
+  //최근 본 목록
+  NOT_FOUND_RECENT_VIEW(HttpStatus.NOT_FOUND, "최근 본 내역이 존재하지 않습니다."),
+  INVALID_RECENT_VIEW_USERID(HttpStatus.FORBIDDEN, "사용자의 최근 본 내역이 아닙니다."),
+
   // 그 외
   UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러")
   ;


### PR DESCRIPTION
## 📌 관련 이슈
- close #184 

## 📝 변경 사항
### AS-IS
- 최근 본 내역 삭제 API의 부재

### TO-BE
- 마이페이지 최근 본 목록 조회 시 최근 본 목록 Id를 응답값에 추가하였습니다. (최근 본 내역 식별을 위해)
- 검증1: 최근 본 내역이 존재하는지
- 검증2: (검증1이 된 상태에서) 해당 최근 본 내역이 본인 소유의 내역인지

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

### 에러 코드
<img width="1524" height="716" alt="image" src="https://github.com/user-attachments/assets/f857ac47-bfe2-467c-9a0e-8548283e8bfc" />
<img width="1524" height="716" alt="image" src="https://github.com/user-attachments/assets/fa8fd4de-63c3-4f7b-8dd0-30ab5ca9185c" />

### 성공 시
<img width="936" height="720" alt="image" src="https://github.com/user-attachments/assets/4d4cd216-4de6-469e-a580-aa49433628da" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
간단한 로직인데 아침이라 빼먹은 부분이 있을수도 있습니다.
잘 봐주시면 감사하겠습니다!