### PR TITLE
[Feature] 경매 목록의 경매 시작 알림 받기 API 구현

### DIFF
--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
@@ -31,8 +31,7 @@ public class NotificationSettingController implements NotificationSettingSpecifi
       @PathVariable Long auctionId,
       @AuthenticationPrincipal CustomUserDetails user
   ) {
-    Long userId = 6L;
-    ReadNotySettingResponse response = notificationSettingService.read(auctionId, userId);
+    ReadNotySettingResponse response = notificationSettingService.read(auctionId, user.getUserId());
     return ApiResponse.ok("알림 세팅 조회를 성공했습니다.", response);
   }
 
@@ -43,10 +42,8 @@ public class NotificationSettingController implements NotificationSettingSpecifi
       @RequestBody UpdateNotySettingRequest request,
       @AuthenticationPrincipal CustomUserDetails user
   ) {
-    Long userId = 6L;
-
     UpdateNotySettingResponse response = notificationSettingService
-        .update(auctionId, request, userId);
+        .update(auctionId, request, user.getUserId());
     return ApiResponse.ok("알림 세팅 수정을 성공했습니다.", response);
   }
 
@@ -57,9 +54,8 @@ public class NotificationSettingController implements NotificationSettingSpecifi
       @RequestBody UpdateAuctionStartNotyRequest request,
       @AuthenticationPrincipal CustomUserDetails user
   ) {
-    Long userId = 6L;
     UpdateAuctionStartNotyResponse response = notificationSettingService
-        .updateAuctionStartNotification(auctionId, request,userId);
+        .updateAuctionStartNotification(auctionId, request, user.getUserId());
     return ApiResponse.ok("경매 시작 알림 (비)활성화를 성공했습니다.", response);
   }
 }

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
@@ -1,5 +1,7 @@
 package com.windfall.api.notificationsetting.controller;
 
+import com.windfall.api.notificationsetting.dto.response.UpdateAuctionStartNotyResponse;
+import com.windfall.api.notificationsetting.dto.request.UpdateAuctionStartNotyRequest;
 import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
 import com.windfall.api.notificationsetting.dto.response.ReadNotySettingResponse;
 import com.windfall.api.notificationsetting.dto.response.UpdateNotySettingResponse;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,7 +31,8 @@ public class NotificationSettingController implements NotificationSettingSpecifi
       @PathVariable Long auctionId,
       @AuthenticationPrincipal CustomUserDetails user
   ) {
-    ReadNotySettingResponse response = notificationSettingService.read(auctionId, user.getUserId());
+    Long userId = 6L;
+    ReadNotySettingResponse response = notificationSettingService.read(auctionId, userId);
     return ApiResponse.ok("알림 세팅 조회를 성공했습니다.", response);
   }
 
@@ -39,8 +43,22 @@ public class NotificationSettingController implements NotificationSettingSpecifi
       @RequestBody UpdateNotySettingRequest request,
       @AuthenticationPrincipal CustomUserDetails user
   ) {
+    Long userId = 6L;
+
     UpdateNotySettingResponse response = notificationSettingService
-        .update(auctionId, request, user.getUserId());
+        .update(auctionId, request, userId);
     return ApiResponse.ok("알림 세팅 수정을 성공했습니다.", response);
+  }
+
+  @PostMapping("/start")
+  public ApiResponse<UpdateAuctionStartNotyResponse> updateAuctionStartNotification(
+      @PathVariable Long auctionId,
+      @RequestBody UpdateAuctionStartNotyRequest request,
+      @AuthenticationPrincipal CustomUserDetails user
+  ) {
+    Long userId = 6L;
+    UpdateAuctionStartNotyResponse response = notificationSettingService
+        .updateAuctionStartNotification(auctionId, request,userId);
+    return ApiResponse.ok("경매 시작 알림 (비)활성화를 성공했습니다.", response);
   }
 }

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingController.java
@@ -50,6 +50,7 @@ public class NotificationSettingController implements NotificationSettingSpecifi
     return ApiResponse.ok("알림 세팅 수정을 성공했습니다.", response);
   }
 
+  @Override
   @PostMapping("/start")
   public ApiResponse<UpdateAuctionStartNotyResponse> updateAuctionStartNotification(
       @PathVariable Long auctionId,

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
@@ -2,6 +2,7 @@ package com.windfall.api.notificationsetting.controller;
 
 import static com.windfall.global.exception.ErrorCode.INVALID_PRICE_NOTIFICATION;
 import static com.windfall.global.exception.ErrorCode.NOT_FOUND_AUCTION;
+import static com.windfall.global.exception.ErrorCode.NOT_FOUND_AUCTION_START_NOTY;
 import static com.windfall.global.exception.ErrorCode.NOT_FOUND_PRICE_REACHED_NOTY;
 import static com.windfall.global.exception.ErrorCode.NOT_FOUND_USER;
 
@@ -45,7 +46,7 @@ public interface NotificationSettingSpecification {
       @AuthenticationPrincipal CustomUserDetails user
   );
 
-  @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_AUCTION})
+  @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_AUCTION, NOT_FOUND_AUCTION_START_NOTY})
   @Operation(summary = "경매 시작 알림 단일 (비)활성화", description = "경매 시작 알림을 (비)활성화할 수 있습니다.")
   ApiResponse<UpdateAuctionStartNotyResponse> updateAuctionStartNotification(
       @Parameter(description = "경매 ID", required = true, example = "1")

--- a/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
+++ b/src/main/java/com/windfall/api/notificationsetting/controller/NotificationSettingSpecification.java
@@ -5,8 +5,10 @@ import static com.windfall.global.exception.ErrorCode.NOT_FOUND_AUCTION;
 import static com.windfall.global.exception.ErrorCode.NOT_FOUND_PRICE_REACHED_NOTY;
 import static com.windfall.global.exception.ErrorCode.NOT_FOUND_USER;
 
+import com.windfall.api.notificationsetting.dto.request.UpdateAuctionStartNotyRequest;
 import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
 import com.windfall.api.notificationsetting.dto.response.ReadNotySettingResponse;
+import com.windfall.api.notificationsetting.dto.response.UpdateAuctionStartNotyResponse;
 import com.windfall.api.notificationsetting.dto.response.UpdateNotySettingResponse;
 import com.windfall.domain.user.entity.CustomUserDetails;
 import com.windfall.global.config.swagger.ApiErrorCodes;
@@ -36,18 +38,21 @@ public interface NotificationSettingSpecification {
       @Parameter(description = "경매 ID", required = true, example = "1")
       @PathVariable Long auctionId,
 
-      @Parameter(description = "알림 여부", required = true,
-          example =
-              """
-              {
-                "auctionStart": true,
-                "auctionEnd": true,
-                "priceReached": true,
-                "price": 10000
-              }
-              """
-      )
+      @Parameter(description = "알림 여부", required = true)
       @RequestBody UpdateNotySettingRequest request,
+
+      @Parameter(description = "사용자 ID", example = "1")
+      @AuthenticationPrincipal CustomUserDetails user
+  );
+
+  @ApiErrorCodes({NOT_FOUND_USER, NOT_FOUND_AUCTION})
+  @Operation(summary = "경매 시작 알림 단일 (비)활성화", description = "경매 시작 알림을 (비)활성화할 수 있습니다.")
+  ApiResponse<UpdateAuctionStartNotyResponse> updateAuctionStartNotification(
+      @Parameter(description = "경매 ID", required = true, example = "1")
+      @PathVariable Long auctionId,
+
+      @Parameter(description = "경매 시작 알림 여부", required = true)
+      @RequestBody UpdateAuctionStartNotyRequest request,
 
       @Parameter(description = "사용자 ID", example = "1")
       @AuthenticationPrincipal CustomUserDetails user

--- a/src/main/java/com/windfall/api/notificationsetting/dto/request/UpdateAuctionStartNotyRequest.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/request/UpdateAuctionStartNotyRequest.java
@@ -1,0 +1,11 @@
+package com.windfall.api.notificationsetting.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "경매 시작 알림 단일 설정 요청 DTO")
+public record UpdateAuctionStartNotyRequest (
+
+    @Schema(description = "경매 시작 설정 여부", example = "true")
+    boolean auctionStart
+){
+}

--- a/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateAuctionStartNotyResponse.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateAuctionStartNotyResponse.java
@@ -1,6 +1,5 @@
 package com.windfall.api.notificationsetting.dto.response;
 
-import com.windfall.api.notificationsetting.dto.request.UpdateAuctionStartNotyRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "경매 시작 알림 단일 설정 응답 DTO")
@@ -9,7 +8,7 @@ public record UpdateAuctionStartNotyResponse (
     @Schema(description = "경매 시작 설정 여부")
     boolean auctionStart
 ){
-  public static UpdateAuctionStartNotyResponse from(UpdateAuctionStartNotyRequest request) {
-    return new UpdateAuctionStartNotyResponse(request.auctionStart());
+  public static UpdateAuctionStartNotyResponse from(boolean activated) {
+    return new UpdateAuctionStartNotyResponse(activated);
   }
 }

--- a/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateAuctionStartNotyResponse.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateAuctionStartNotyResponse.java
@@ -1,0 +1,15 @@
+package com.windfall.api.notificationsetting.dto.response;
+
+import com.windfall.api.notificationsetting.dto.request.UpdateAuctionStartNotyRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "경매 시작 알림 단일 설정 응답 DTO")
+public record UpdateAuctionStartNotyResponse (
+
+    @Schema(description = "경매 시작 설정 여부")
+    boolean auctionStart
+){
+  public static UpdateAuctionStartNotyResponse from(UpdateAuctionStartNotyRequest request) {
+    return new UpdateAuctionStartNotyResponse(request.auctionStart());
+  }
+}

--- a/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateNotySettingResponse.java
+++ b/src/main/java/com/windfall/api/notificationsetting/dto/response/UpdateNotySettingResponse.java
@@ -1,7 +1,12 @@
 package com.windfall.api.notificationsetting.dto.response;
 
-import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
+import com.windfall.domain.notification.entity.NotificationSetting;
+import com.windfall.domain.notification.entity.PriceNotification;
+import com.windfall.domain.notification.enums.NotificationSettingType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Schema(description = "알림 세팅 수정 응답 DTO")
 public record UpdateNotySettingResponse (
@@ -19,12 +24,22 @@ public record UpdateNotySettingResponse (
     Long price
 ) {
 
-  public static UpdateNotySettingResponse from(UpdateNotySettingRequest request) {
-      return new UpdateNotySettingResponse(
-          request.auctionStart(),
-          request.auctionEnd(),
-          request.priceReached(),
-          request.price()
-      );
+  public static UpdateNotySettingResponse of(
+      List<NotificationSetting> settings,
+      PriceNotification priceNotification
+  ) {
+    Map<NotificationSettingType, Boolean> map =
+        settings.stream()
+            .collect(Collectors.toMap(
+                NotificationSetting::getType,
+                NotificationSetting::isActivated
+            ));
+
+    return new UpdateNotySettingResponse(
+        map.getOrDefault(NotificationSettingType.AUCTION_START, false),
+        map.getOrDefault(NotificationSettingType.AUCTION_END, false),
+        map.getOrDefault(NotificationSettingType.PRICE_REACHED, false),
+        priceNotification != null ? priceNotification.getTargetPrice() : null
+    );
   }
 }

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -66,7 +66,14 @@ public class NotificationSettingService {
       upsertPriceNotification(userId, auctionId, request.price());
     }
 
-    return UpdateNotySettingResponse.from(request);
+    List<NotificationSetting> settings =
+        notificationSettingRepository.findByUserIdAndAuctionId(userId, auctionId);
+
+    PriceNotification priceNotification = priceNotificationRepository
+        .findByUserIdAndAuctionId(userId, auctionId)
+        .orElse(null);
+
+    return UpdateNotySettingResponse.of(settings, priceNotification);
   }
 
   @Transactional
@@ -80,7 +87,11 @@ public class NotificationSettingService {
 
     upsert(user, auction, NotificationSettingType.AUCTION_START, request.auctionStart());
 
-    return UpdateAuctionStartNotyResponse.from(request);
+    NotificationSetting setting = notificationSettingRepository.findByUserIdAndAuctionIdAndType(
+        userId, auctionId, NotificationSettingType.AUCTION_START)
+        .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_AUCTION_START_NOTY));
+
+    return UpdateAuctionStartNotyResponse.from(setting.isActivated());
   }
 
   private void validatePrice(UpdateNotySettingRequest request) {

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -134,13 +134,4 @@ public class NotificationSettingService {
     pn.updateTargetPrice(price);
     pn.resetNotified();
   }
-
-  // 알림 발송 판단용
-  @Transactional(readOnly = true)
-  public boolean isEnabled(Long userId, Long auctionId, NotificationSettingType type) {
-    return notificationSettingRepository
-        .findByUserIdAndAuctionIdAndType(userId, auctionId, type)
-        .map(NotificationSetting::isActivated)
-        .orElse(false); // row 없으면 비활성화 반환
-  }
 }

--- a/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
+++ b/src/main/java/com/windfall/api/notificationsetting/service/NotificationSettingService.java
@@ -1,7 +1,9 @@
 package com.windfall.api.notificationsetting.service;
 
+import com.windfall.api.notificationsetting.dto.request.UpdateAuctionStartNotyRequest;
 import com.windfall.api.notificationsetting.dto.request.UpdateNotySettingRequest;
 import com.windfall.api.notificationsetting.dto.response.ReadNotySettingResponse;
+import com.windfall.api.notificationsetting.dto.response.UpdateAuctionStartNotyResponse;
 import com.windfall.api.notificationsetting.dto.response.UpdateNotySettingResponse;
 import com.windfall.domain.auction.entity.Auction;
 import com.windfall.domain.auction.repository.AuctionRepository;
@@ -65,6 +67,20 @@ public class NotificationSettingService {
     }
 
     return UpdateNotySettingResponse.from(request);
+  }
+
+  @Transactional
+  public UpdateAuctionStartNotyResponse updateAuctionStartNotification(
+      Long auctionId,
+      UpdateAuctionStartNotyRequest request,
+      Long userId
+  ) {
+    User user = getUser(userId);
+    Auction auction = getAuction(auctionId);
+
+    upsert(user, auction, NotificationSettingType.AUCTION_START, request.auctionStart());
+
+    return UpdateAuctionStartNotyResponse.from(request);
   }
 
   private void validatePrice(UpdateNotySettingRequest request) {

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
   INVALID_NOTIFICATION(HttpStatus.FORBIDDEN, "해당 유저의 알림이 아닙니다."),
   INVALID_PRICE_NOTIFICATION(HttpStatus.BAD_REQUEST, "가격 도달 알림을 위한 가격이 유효하지 않습니다."),
   NOT_FOUND_PRICE_REACHED_NOTY(HttpStatus.INTERNAL_SERVER_ERROR, "알림 설정 처리 중 내부 오류로 가격 도달 알림이 활성화 되지 않았습니다."),
+  NOT_FOUND_AUCTION_START_NOTY(HttpStatus.INTERNAL_SERVER_ERROR, "알림 설정 처리 중 내부 오류로 경매 시작 알림이 활성화 되지 않았습니다."),
 
   // WS CONNECT/인증 단계 구체 에러
   WS_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "웹소켓 연결에 토큰이 필요합니다."),

--- a/src/test/java/com/windfall/api/notificationsetting/NotificationSettingServiceTest.java
+++ b/src/test/java/com/windfall/api/notificationsetting/NotificationSettingServiceTest.java
@@ -102,41 +102,4 @@ class NotificationSettingServiceTest {
 
     verify(notificationSettingRepository, times(3)).save(any(NotificationSetting.class));
   }
-
-  @Test
-  @DisplayName("[알림 세팅 확인1] row가 존재할 때 isEnabled 반환")
-  void isEnabled_returnsCorrectValue() {
-    // given
-    NotificationSetting setting = NotificationSetting.builder()
-        .user(user)
-        .auction(auction)
-        .type(NotificationSettingType.AUCTION_START)
-        .build();
-    setting.updateActivated(true);
-
-    when(notificationSettingRepository.findByUserIdAndAuctionIdAndType(
-        userId, auctionId, NotificationSettingType.AUCTION_START))
-        .thenReturn(Optional.of(setting));
-
-    // when
-    boolean enabled = service.isEnabled(userId, auctionId, NotificationSettingType.AUCTION_START);
-
-    // then
-    assertTrue(enabled);
-  }
-
-  @Test
-  @DisplayName("[알림 세팅 확인2] row가 없을 때 isEnabled 반환 false")
-  void isEnabled_returnsFalseIfNoRow() {
-    // given
-    when(notificationSettingRepository.findByUserIdAndAuctionIdAndType(
-        userId, auctionId, NotificationSettingType.AUCTION_START))
-        .thenReturn(Optional.empty());
-
-    // when
-    boolean enabled = service.isEnabled(userId, auctionId, NotificationSettingType.AUCTION_START);
-
-    // then
-    assertFalse(enabled);
-  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #191

## 📝 변경 사항
### AS-IS
- 경매 목록에 경매 시작 알림 받기 기능 부재
- 기존 코드에서 응답을 DB에서 가져오지 않은 문제

### TO-BE
- 경매 목록의 경매 시작 알림 받기 API 구현 + 스웨거 추가
- DB에서 값 가져와서 응답 값을 반환
- 중복 코드 리팩토링

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [X] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [X] 코딩 컨벤션을 준수했나요?
- [X] 불필요한 코드는 제거했나요?
- [X] 주석은 충분히 작성했나요?
- [X] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 경매 목록에서 경매 시작 알림 받기 API 구현을 미처 못해서 추가했습니다.