### PR TITLE
[Fix] RecentView userId null 에러 픽스

### DIFF
--- a/src/main/java/com/windfall/api/recentview/controller/RecentViewController.java
+++ b/src/main/java/com/windfall/api/recentview/controller/RecentViewController.java
@@ -25,7 +25,10 @@ public class RecentViewController implements RecentViewSpecification {
       @AuthenticationPrincipal CustomUserDetails userDetails
   ){
 
-    Long userId = userDetails.getUserId();
+    Long userId = null;
+    if (userDetails != null) {
+      userId = userDetails.getUserId();
+    }
     recentViewService.record(auctionId, userId);
 
     return ApiResponse.ok("최근 본 목록이 업데이트 되었습니다.", null);

--- a/src/main/java/com/windfall/api/recentview/service/RecentViewService.java
+++ b/src/main/java/com/windfall/api/recentview/service/RecentViewService.java
@@ -21,7 +21,7 @@ public class RecentViewService {
   @Transactional
   public void record(Long auctionId, Long userId){
 
-    if(isLoginUser(userId)) return; //비회원이면 해당 로직 실행할 필요가 없음
+    if(!isLoginUser(userId)) return; //비회원이면 해당 로직 실행할 필요가 없음
 
     Auction auction = auctionRepository.findById(auctionId).orElseThrow(() -> new ErrorException(
         ErrorCode.NOT_FOUND_AUCTION));
@@ -70,6 +70,6 @@ public class RecentViewService {
   }
 
   private boolean isLoginUser(Long userId){
-    return userId == null;
+    return userId != null;
   }
 }

--- a/src/main/java/com/windfall/api/recentview/service/RecentViewService.java
+++ b/src/main/java/com/windfall/api/recentview/service/RecentViewService.java
@@ -21,6 +21,8 @@ public class RecentViewService {
   @Transactional
   public void record(Long auctionId, Long userId){
 
+    if(isLoginUser(userId)) return; //비회원이면 해당 로직 실행할 필요가 없음
+
     Auction auction = auctionRepository.findById(auctionId).orElseThrow(() -> new ErrorException(
         ErrorCode.NOT_FOUND_AUCTION));
 
@@ -65,5 +67,9 @@ public class RecentViewService {
       RecentView recentView = recentViewRepository.findTop1ByUserIdOrderByViewedAt(userId);
       recentViewRepository.delete(recentView);
     }
+  }
+
+  private boolean isLoginUser(Long userId){
+    return userId == null;
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #194 

## 📝 변경 사항
### AS-IS
- 비로그인 사용자가 경매 상세에 들어갔을 떄 같이 실행되는 최근 본 목록 api가 비로그인 사용자의 경우의 분기처리를 해놓지 않았음.

### TO-BE
- 비로그인 사용자는 최근 본 목록을 기록하는 로직이 실행되지 않도록 처리하였습니다. (NPE 방지)

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
감사합니다.