### PR TITLE
[Fix] 비로그인일 때 데이터가 여러 개 뜨는 문제

### DIFF
--- a/src/main/java/com/windfall/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/com/windfall/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -261,7 +261,7 @@ private BooleanExpression priceBetween(Long minPrice, Long maxPrice) {
       Long userId
   ) {
     if (userId == null) {
-      return Expressions.TRUE;
+      return Expressions.FALSE;
     }
 
     return notificationSetting.auction.eq(auction)


### PR DESCRIPTION
## 📌 관련 이슈
- close #197

## 📝 변경 사항
### AS-IS
- 유저가 비로그인일 때 데이터가 중복되는 문제
-> 유저 비로그인 시 항상 조인을 참으로 둠
-> 무한 참조하는 문제 발생


### TO-BE
- 유저 비로그인 시 조인을 항상 false로 둠

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="916" height="872" alt="image" src="https://github.com/user-attachments/assets/70150efc-5fe4-4cef-9e0c-687c95695285" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 참으로 둬도 문제가 없을 것 같아서 해두었지만, 무한 참조되는 문제가 있네여....