### PR TITLE
[Refactor] UserInfo 및 Sales History 비회원 조회할 수 있도록 null 처리 수정

### DIFF
--- a/src/main/java/com/windfall/api/user/controller/UserinfoController.java
+++ b/src/main/java/com/windfall/api/user/controller/UserinfoController.java
@@ -38,7 +38,10 @@ public class UserinfoController implements UserInfoSpecification{
   public ApiResponse<UserInfoResponse> getUserInfo(
       @PathVariable Long userid,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    Long loginId = userDetails.getUserId();
+    Long loginId = null;
+    if (userDetails != null) {
+      loginId = userDetails.getUserId();
+    }
 
     UserInfoResponse response = userInfoService.getUserInfo(userid, loginId);
 
@@ -52,8 +55,10 @@ public class UserinfoController implements UserInfoSpecification{
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestParam(required = false) String filter,
       @PageableDefault(page = 0, size = 10) Pageable pageable) {
-
-    Long loginId = userDetails.getUserId();
+    Long loginId = null;
+    if (userDetails != null) {
+      loginId = userDetails.getUserId();
+    }
 
     SliceResponse<BaseSalesHistoryResponse> response = userInfoService.getUserSalesHistory(userid, loginId, filter, pageable);
 

--- a/src/main/java/com/windfall/domain/user/repository/UserInfoRepository.java
+++ b/src/main/java/com/windfall/domain/user/repository/UserInfoRepository.java
@@ -15,7 +15,10 @@ public interface UserInfoRepository extends JpaRepository<User, Long> {
   @Query("""
   SELECT
   new com.windfall.api.user.dto.response.UserInfoResponse(
-  (u.id = :loginId),
+  CASE
+    WHEN :loginId IS NOT NULL AND u.id = :loginId THEN true
+    ELSE false
+  END,
   u.id,
   u.nickname,
   u.email,


### PR DESCRIPTION
## 📌 관련 이슈
- close #202

## 📝 변경 사항
### AS-IS
- UserInfo 및 Sales History 비회원 조회할 수 있도록 null 처리 수정

### TO-BE
- null 로직 추가 및 쿼리에서 null 날아올거 대비해서 CASE문 적용

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
자고싶어용