### PR TITLE
[Refactor] 실시간 인기순 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     //implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.3.0")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/src/main/java/com/windfall/api/auction/service/AuctionImageService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionImageService.java
@@ -99,8 +99,8 @@ public class AuctionImageService {
   }
 
   private String generateObjectKey() {
-    int path = LocalDateTime.now().getNano();
-    return  path + "/" + UUID.randomUUID();
+    String path = "auction/images/";
+    return  path + UUID.randomUUID();
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/windfall/api/auction/service/AuctionService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionService.java
@@ -52,6 +52,7 @@ public class AuctionService {
   private final AuctionLikeService auctionLikeService;
   private final AuctionImageService auctionImageService;
   private final SearchHistoryService searchHistoryService;
+  private final AuctionViewerService auctionViewerService;
 
   @Transactional
   public AuctionCreateResponse createAuction(AuctionCreateRequest request, Long sellerId) {
@@ -94,8 +95,7 @@ public class AuctionService {
   public AuctionListReadResponse readAuctionList(Long userId) {
     List<ScheduledInfo> scheduleList = auctionRepository.getScheduledInfo(AuctionStatus.SCHEDULED, userId,15);
     List<ProcessInfo> processList = auctionRepository.getProcessInfo(AuctionStatus.PROCESS, 15);
-    List<PopularInfo> popularList = auctionRepository.getPopularInfo(AuctionStatus.PROCESS, 15);
-
+    List<PopularInfo> popularList = auctionViewerService.getPopularInfo();
     LocalDateTime now = LocalDateTime.now();
 
     if (userId != null) {
@@ -111,6 +111,7 @@ public class AuctionService {
 
     return AuctionListReadResponse.of(now, popularList, processList, scheduleList);
   }
+
 
   private List<? extends AuctionLikeSupport<?>> mergeAuctionLikeTargets(
       List<PopularInfo> popularList, List<ProcessInfo> processList,

--- a/src/main/java/com/windfall/api/auction/service/AuctionViewerService.java
+++ b/src/main/java/com/windfall/api/auction/service/AuctionViewerService.java
@@ -1,6 +1,17 @@
 package com.windfall.api.auction.service;
 
+import com.windfall.api.auction.dto.response.info.PopularInfo;
+import com.windfall.domain.auction.enums.AuctionStatus;
+import com.windfall.domain.auction.repository.AuctionRepository;
+import com.windfall.global.exception.ErrorCode;
+import com.windfall.global.exception.ErrorException;
+import io.github.resilience4j.retry.annotation.Retry;
 import java.time.Duration;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -10,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class AuctionViewerService {
 
   private final RedisTemplate<String, String> redisTemplate;
+  private final AuctionRepository auctionRepository;
 
   private String getViewerKey(Long auctionId) {
     return "auction:" + auctionId + ":viewers";
@@ -18,10 +30,16 @@ public class AuctionViewerService {
   private String getSessionKey(String sessionId) {
     return "session:" + sessionId + ":auction";
   }
+  private static final String RANKING_KEY = "auction:rankings";
 
   public long addViewer(Long auctionId, String sessionId) {
     redisTemplate.opsForSet().add(getViewerKey(auctionId), sessionId);
     redisTemplate.opsForValue().set(getSessionKey(sessionId), String.valueOf(auctionId), Duration.ofHours(3));
+
+    // 추가 코드
+    long viewerCount = getViewerCount(auctionId);
+
+    updateRanking(auctionId, viewerCount);
 
     return getViewerCount(auctionId);
   }
@@ -38,6 +56,16 @@ public class AuctionViewerService {
     redisTemplate.opsForSet().remove(getViewerKey(auctionId), sessionId);
     redisTemplate.delete(getSessionKey(sessionId));
 
+    // 추가 코드
+    long viewerCount = getViewerCount(auctionId);
+
+    if (viewerCount == 0) {
+      redisTemplate.opsForZSet()
+          .remove(RANKING_KEY, auctionIdStr);
+    } else {
+      updateRanking(auctionId, viewerCount);
+    }
+
     return auctionId;
   }
 
@@ -48,5 +76,52 @@ public class AuctionViewerService {
       return 0L;
     }
     return size;
+  }
+
+  // 재시도 로직은 AOP가 되어야 작동이 되는 문제로 메소드를 여기에 두었습니다.
+  @Retry(name = "customRetry", fallbackMethod = "fallbackPopularInfo")
+  public List<PopularInfo> getPopularInfo(){
+    List<Long> rankedIds = getTop15AuctionIds();
+
+    List<PopularInfo> popularList = auctionRepository.getPopularInfo(rankedIds);
+
+    if(popularList.isEmpty() || rankedIds.isEmpty()){
+      throw new ErrorException(ErrorCode.POPULAR_AUCTION_FETCH_FAIL);
+    }
+
+    Map<Long, Integer> orderMap = new HashMap<>();
+
+    for (int i = 0; i < rankedIds.size(); i++) {
+      orderMap.put(rankedIds.get(i), i);
+    }
+
+    popularList.sort(
+        Comparator.comparingInt(a -> orderMap.get(a.auctionId()))
+    );
+
+    return popularList;
+  }
+
+  private List<PopularInfo> fallbackPopularInfo(Exception e){
+    return auctionRepository.fallbackPopularInfo(AuctionStatus.PROCESS,15);
+  }
+
+  public List<Long> getTop15AuctionIds() {
+    Set<String> topAuctionIds =
+        redisTemplate.opsForZSet()
+            .reverseRange(RANKING_KEY, 0, 14);
+
+    if (topAuctionIds == null || topAuctionIds.isEmpty()) {
+      return List.of();
+    }
+
+    return topAuctionIds.stream()
+        .map(Long::valueOf)
+        .toList();
+  }
+
+  private void updateRanking(Long auctionId, long viewerCount) {
+    redisTemplate.opsForZSet()
+        .add(RANKING_KEY, String.valueOf(auctionId), viewerCount);
   }
 }

--- a/src/main/java/com/windfall/domain/auction/repository/AuctionRepositoryCustom.java
+++ b/src/main/java/com/windfall/domain/auction/repository/AuctionRepositoryCustom.java
@@ -14,7 +14,7 @@ import org.springframework.data.domain.Slice;
 public interface AuctionRepositoryCustom {
   List<ProcessInfo> getProcessInfo(AuctionStatus status, int limit);
   List<ScheduledInfo> getScheduledInfo(AuctionStatus status,Long userId, int limit);
-  List<PopularInfo> getPopularInfo(AuctionStatus status, int limit);
-
+  List<PopularInfo> getPopularInfo(List<Long> auctionIds);
+  List<PopularInfo> fallbackPopularInfo(AuctionStatus status, int limit);
   Slice<AuctionSearchResponse> searchAuction(Pageable pageable,String query, AuctionCategory category, AuctionStatus status, Long minPrice, Long maxPrice, List<Long> tagIds,Long userId);
 }

--- a/src/main/java/com/windfall/global/exception/ErrorCode.java
+++ b/src/main/java/com/windfall/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
   INVALID_AUCTION_SELLER(HttpStatus.FORBIDDEN, "해당 경매의 판매자가 아닙니다."),
   AUCTION_CANNOT_DELETE(HttpStatus.CONFLICT, "현재 상태의 경매는 삭제할 수 없습니다."),
   AUCTION_CANNOT_CANCEL(HttpStatus.CONFLICT, "현재 상태의 경매는 취소할 수 없습니다."),
+  POPULAR_AUCTION_FETCH_FAIL(HttpStatus.BAD_REQUEST, "인기 경매 목록을 불러오는 데 실패했습니다."),
 
   // 경매 이미지
   INVALID_S3_UPLOAD(HttpStatus.BAD_GATEWAY,"S3 이미지 업로드 실패했습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,3 +102,12 @@ management:
   health:
     redis:
       enabled: false # 헬스체크 최소화
+
+resilience4j:
+  retry:
+    configs:
+      customRetry:
+        maxAttempts: 3
+        waitDuration: 2s
+        enableExponentialBackoff: true
+        exponential-backoff-multiplier: 2.0


### PR DESCRIPTION
## 📌 관련 이슈
- close #205

## 📝 변경 사항
### AS-IS
- 스케줄러를 통해 5분마다 값을 받아오는 로직에서 실시간 인기순을 진행하는 문제

### TO-BE
- 레디스 sorted set을 이용하여 실시간으로 인기 순을 진행합니다.
- 레디스 오류 대책으로 Mysql로 직접 fallback을 해줍니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="1174" height="794" alt="image" src="https://github.com/user-attachments/assets/468f74fd-167d-49e9-83ed-fbf686e79ba6" />
<img width="1162" height="472" alt="image" src="https://github.com/user-attachments/assets/d4c6c2ce-aeb6-47df-9cb3-1cf9b596a638" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 재시도 로직은 AOP 때문에 다른 클래스에서 이동을 해야 동작이 되어 viewService에 우선은 저장했습니다.