### PR TITLE
[Feature] 리뷰 등록 시 알림 전송 로직 구현

### DIFF
--- a/src/main/java/com/windfall/api/notification/service/SseService.java
+++ b/src/main/java/com/windfall/api/notification/service/SseService.java
@@ -146,6 +146,19 @@ public class SseService {
     );
   }
 
+  @Async("socketTaskExecutor")
+  @Transactional
+  public void sendReviewRegistered(Long userId, Long targetId) {
+    sendNotification(
+        userId,
+        targetId,
+        "리뷰 등록 알림",
+        "구매자가 리뷰를 등록했습니다.",
+        NotificationType.REVIEW_REGISTERED,
+        "reviewRegistered"
+    );
+  }
+
   private void sendNotification(
       Long userId,
       Long targetId,

--- a/src/main/java/com/windfall/api/review/service/ReviewService.java
+++ b/src/main/java/com/windfall/api/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.windfall.api.review.service;
 
+import com.windfall.api.notification.service.SseService;
 import com.windfall.api.review.dto.request.CreateReviewRequest;
 import com.windfall.api.review.dto.request.UpdateReviewRequest;
 import com.windfall.api.review.dto.response.CreateReviewResponse;
@@ -26,6 +27,7 @@ public class ReviewService {
   private final TradeRepository tradeRepository;
   private final ReviewRepository reviewRepository;
   private final AuctionImageRepository auctionImageRepository;
+  private final SseService sseService;
 
   @Transactional
   public CreateReviewResponse createReview(Long userId, CreateReviewRequest request) {
@@ -51,6 +53,8 @@ public class ReviewService {
 
     Review review = Review.createReview(trade, request.rating(), request.content());
     reviewRepository.save(review);
+
+    notifyReviewRegistered(trade.getSellerId(), review.getId());
 
     return CreateReviewResponse.from(review);
   }
@@ -103,4 +107,10 @@ public class ReviewService {
     }
   }
 
+  private void notifyReviewRegistered(Long sellerId, Long reviewId) {
+    sseService.sendReviewRegistered(
+        sellerId,
+        reviewId
+    );
+  }
 }

--- a/src/main/java/com/windfall/domain/notification/enums/NotificationSettingType.java
+++ b/src/main/java/com/windfall/domain/notification/enums/NotificationSettingType.java
@@ -9,7 +9,8 @@ public enum NotificationSettingType {
 
   AUCTION_START("경매 시작"),
   AUCTION_END("경매 종료"),
-  PRICE_REACHED("가격 도달");
+  PRICE_REACHED("가격 도달"),
+  REVIEW_REGISTERED("리뷰 등록");
 
   private final String description;
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #210 

## 📝 변경 사항
### AS-IS
- 판매자 리뷰 등록 시 알림 전송 부재

### TO-BE
1. SseService 기능 확장
     - `sendReviewRegistered` 메서드 추가

2. ReviewService 로직 개선
     - 알림 트리거 연동:
      `reviewRepository.save(review)` 성공 후, `SseService`를 호출하여 비동기 알림 발송

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="976" height="514" alt="image" src="https://github.com/user-attachments/assets/d5d8d8e7-ffd2-4939-87dc-a66b829bd084" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
알림 발송 시 경매 제목도 포함할까 고민했지만 불필요한 Auction 엔티티까지 조회가 필요해서 이 부분은 기존 방식을 유지하도록 했습니다 ~